### PR TITLE
Mention dcrwallet version requirements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Pre-requirements:
 
   - Go 1.9 or later
   - [dep](https://github.com/golang/dep)
+  - Latest `dcrwallet` built from master (for `dcratomicswap`)
 
 ```
 $ cd $GOPATH/src/github.com/decred


### PR DESCRIPTION
Several users have hit issues trying to use dcratomicswap with the
latest release version of dcrwallet that is missing the
WalletSevice.CreateSignature gRPC method.

This requirement can be updated for the next release when that occurs.