### PR TITLE
Switch from RIPEMD160 to SHA256 secret hashes.

### DIFF
--- a/cmd/btcatomicswap/main.go
+++ b/cmd/btcatomicswap/main.go
@@ -8,6 +8,7 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -51,7 +52,7 @@ var (
 // initiator can be on either chain.  This tool only deals with creating the
 // Bitcoin transactions for these swaps.  A second tool should be used for the
 // transaction on the other chain.  Any chain can be used so long as it supports
-// OP_RIPEMD160 and OP_CHECKLOCKTIMEVERIFY.
+// OP_SHA256 and OP_CHECKLOCKTIMEVERIFY.
 //
 // Example scenerios using bitcoin as the second chain:
 //
@@ -243,7 +244,7 @@ func run() (err error, showUsage bool) {
 		if err != nil {
 			return errors.New("secret hash must be hex encoded"), true
 		}
-		if len(secretHash) != ripemd160.Size {
+		if len(secretHash) != sha256.Size {
 			return errors.New("secret hash has wrong size"), true
 		}
 
@@ -305,7 +306,7 @@ func run() (err error, showUsage bool) {
 		if err != nil {
 			return errors.New("secret hash must be hex encoded"), true
 		}
-		if len(secretHash) != ripemd160.Size {
+		if len(secretHash) != sha256.Size {
 			return errors.New("secret hash has wrong size"), true
 		}
 
@@ -716,10 +717,9 @@ func buildRefund(c *rpc.Client, contract []byte, contractTx *wire.MsgTx, feePerK
 	return refundTx, refundFee, nil
 }
 
-func ripemd160Hash(x []byte) []byte {
-	h := ripemd160.New()
-	h.Write(x)
-	return h.Sum(nil)
+func sha256Hash(x []byte) []byte {
+	h := sha256.Sum256(x)
+	return h[:]
 }
 
 func calcFeePerKb(absoluteFee btcutil.Amount, serializeSize int) float64 {
@@ -732,7 +732,7 @@ func (cmd *initiateCmd) runCommand(c *rpc.Client) error {
 	if err != nil {
 		return err
 	}
-	secretHash := ripemd160Hash(secret[:])
+	secretHash := sha256Hash(secret[:])
 
 	// locktime after 500,000,000 (Tue Nov  5 00:53:20 1985 UTC) is interpreted
 	// as a unix time rather than a block height.
@@ -951,7 +951,7 @@ func (cmd *extractSecretCmd) runOfflineCommand() error {
 			return err
 		}
 		for _, push := range pushes {
-			if bytes.Equal(ripemd160Hash(push), cmd.secretHash) {
+			if bytes.Equal(sha256Hash(push), cmd.secretHash) {
 				fmt.Printf("Secret: %x\n", push)
 				return nil
 			}
@@ -1043,10 +1043,8 @@ func atomicSwapContract(pkhMe, pkhThem *[ripemd160.Size]byte, locktime int64, se
 
 	b.AddOp(txscript.OP_IF) // Normal redeem path
 	{
-		// Require initiator's secret to be known to redeem the output.  A
-		// ripemd160 hash is used here as it is the only shared hash opcode
-		// between decred and bitcoin.
-		b.AddOp(txscript.OP_RIPEMD160)
+		// Require initiator's secret to be known to redeem the output.
+		b.AddOp(txscript.OP_SHA256)
 		b.AddData(secretHash)
 		b.AddOp(txscript.OP_EQUALVERIFY)
 

--- a/cmd/dcratomicswap/main.go
+++ b/cmd/dcratomicswap/main.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"flag"
@@ -65,7 +66,7 @@ var (
 // initiator can be on either chain.  This tool only deals with creating the
 // Decred transactions for these swaps.  A second tool should be used for the
 // transaction on the other chain.  Any chain can be used so long as it supports
-// OP_RIPEMD160 and OP_CHECKLOCKTIMEVERIFY.
+// OP_SHA256 and OP_CHECKLOCKTIMEVERIFY.
 //
 // Example scenerios using bitcoin as the second chain:
 //
@@ -257,7 +258,7 @@ func run() (err error, showUsage bool) {
 		if err != nil {
 			return errors.New("secret hash must be hex encoded"), true
 		}
-		if len(secretHash) != ripemd160.Size {
+		if len(secretHash) != sha256.Size {
 			return errors.New("secret hash has wrong size"), true
 		}
 
@@ -319,7 +320,7 @@ func run() (err error, showUsage bool) {
 		if err != nil {
 			return errors.New("secret hash must be hex encoded"), true
 		}
-		if len(secretHash) != ripemd160.Size {
+		if len(secretHash) != sha256.Size {
 			return errors.New("secret hash has wrong size"), true
 		}
 
@@ -636,10 +637,9 @@ func buildRefund(ctx context.Context, c pb.WalletServiceClient, contract []byte,
 	return refundTx, refundFee, nil
 }
 
-func ripemd160Hash(x []byte) []byte {
-	h := ripemd160.New()
-	h.Write(x)
-	return h.Sum(nil)
+func sha256Hash(x []byte) []byte {
+	h := sha256.Sum256(x)
+	return h[:]
 }
 
 func calcFeePerKb(absoluteFee dcrutil.Amount, serializeSize int) float64 {
@@ -652,7 +652,7 @@ func (cmd *initiateCmd) runCommand(ctx context.Context, c pb.WalletServiceClient
 	if err != nil {
 		return err
 	}
-	secretHash := ripemd160Hash(secret[:])
+	secretHash := sha256Hash(secret[:])
 
 	// locktime after 500,000,000 (Tue Nov  5 00:53:20 1985 UTC) is interpreted
 	// as a unix time rather than a block height.
@@ -907,7 +907,7 @@ func (cmd *extractSecretCmd) runOfflineCommand() error {
 			return err
 		}
 		for _, push := range pushes {
-			if bytes.Equal(ripemd160Hash(push), cmd.secretHash) {
+			if bytes.Equal(sha256Hash(push), cmd.secretHash) {
 				fmt.Printf("Secret: %x\n", push)
 				return nil
 			}
@@ -999,10 +999,8 @@ func atomicSwapContract(pkhMe, pkhThem *[ripemd160.Size]byte, locktime int64, se
 
 	b.AddOp(txscript.OP_IF) // Normal redeem path
 	{
-		// Require initiator's secret to be known to redeem the output.  A
-		// ripemd160 hash is used here as it is the only shared hash opcode
-		// between decred and bitcoin.
-		b.AddOp(txscript.OP_RIPEMD160)
+		// Require initiator's secret to be known to redeem the output.
+		b.AddOp(txscript.OP_SHA256)
 		b.AddData(secretHash)
 		b.AddOp(txscript.OP_EQUALVERIFY)
 

--- a/cmd/ltcatomicswap/main.go
+++ b/cmd/ltcatomicswap/main.go
@@ -8,6 +8,7 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -51,7 +52,7 @@ var (
 // initiator can be on either chain.  This tool only deals with creating the
 // Litecoin transactions for these swaps.  A second tool should be used for the
 // transaction on the other chain.  Any chain can be used so long as it supports
-// OP_RIPEMD160 and OP_CHECKLOCKTIMEVERIFY.
+// OP_SHA256 and OP_CHECKLOCKTIMEVERIFY.
 //
 // Example scenerios using litecoin as the second chain:
 //
@@ -243,7 +244,7 @@ func run() (err error, showUsage bool) {
 		if err != nil {
 			return errors.New("secret hash must be hex encoded"), true
 		}
-		if len(secretHash) != ripemd160.Size {
+		if len(secretHash) != sha256.Size {
 			return errors.New("secret hash has wrong size"), true
 		}
 
@@ -305,7 +306,7 @@ func run() (err error, showUsage bool) {
 		if err != nil {
 			return errors.New("secret hash must be hex encoded"), true
 		}
-		if len(secretHash) != ripemd160.Size {
+		if len(secretHash) != sha256.Size {
 			return errors.New("secret hash has wrong size"), true
 		}
 
@@ -716,10 +717,9 @@ func buildRefund(c *rpc.Client, contract []byte, contractTx *wire.MsgTx, feePerK
 	return refundTx, refundFee, nil
 }
 
-func ripemd160Hash(x []byte) []byte {
-	h := ripemd160.New()
-	h.Write(x)
-	return h.Sum(nil)
+func sha256Hash(x []byte) []byte {
+	h := sha256.Sum256(x)
+	return h[:]
 }
 
 func calcFeePerKb(absoluteFee ltcutil.Amount, serializeSize int) float64 {
@@ -732,7 +732,7 @@ func (cmd *initiateCmd) runCommand(c *rpc.Client) error {
 	if err != nil {
 		return err
 	}
-	secretHash := ripemd160Hash(secret[:])
+	secretHash := sha256Hash(secret[:])
 
 	// locktime after 500,000,000 (Tue Nov  5 00:53:20 1985 UTC) is interpreted
 	// as a unix time rather than a block height.
@@ -951,7 +951,7 @@ func (cmd *extractSecretCmd) runOfflineCommand() error {
 			return err
 		}
 		for _, push := range pushes {
-			if bytes.Equal(ripemd160Hash(push), cmd.secretHash) {
+			if bytes.Equal(sha256Hash(push), cmd.secretHash) {
 				fmt.Printf("Secret: %x\n", push)
 				return nil
 			}
@@ -1043,10 +1043,8 @@ func atomicSwapContract(pkhMe, pkhThem *[ripemd160.Size]byte, locktime int64, se
 
 	b.AddOp(txscript.OP_IF) // Normal redeem path
 	{
-		// Require initiator's secret to be known to redeem the output.  A
-		// ripemd160 hash is used here as it is the only shared hash opcode
-		// between decred and litecoin.
-		b.AddOp(txscript.OP_RIPEMD160)
+		// Require initiator's secret to be known to redeem the output.
+		b.AddOp(txscript.OP_SHA256)
 		b.AddData(secretHash)
 		b.AddOp(txscript.OP_EQUALVERIFY)
 

--- a/cmd/vtcatomicswap/main.go
+++ b/cmd/vtcatomicswap/main.go
@@ -10,6 +10,7 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -53,7 +54,7 @@ var (
 // initiator can be on either chain.  This tool only deals with creating the
 // Vertcoin transactions for these swaps.  A second tool should be used for the
 // transaction on the other chain.  Any chain can be used so long as it supports
-// OP_RIPEMD160 and OP_CHECKLOCKTIMEVERIFY.
+// OP_SHA256 and OP_CHECKLOCKTIMEVERIFY.
 //
 // Example scenerios using Vertcoin as the second chain:
 //
@@ -245,7 +246,7 @@ func run() (err error, showUsage bool) {
 		if err != nil {
 			return errors.New("secret hash must be hex encoded"), true
 		}
-		if len(secretHash) != ripemd160.Size {
+		if len(secretHash) != sha256.Size {
 			return errors.New("secret hash has wrong size"), true
 		}
 
@@ -307,7 +308,7 @@ func run() (err error, showUsage bool) {
 		if err != nil {
 			return errors.New("secret hash must be hex encoded"), true
 		}
-		if len(secretHash) != ripemd160.Size {
+		if len(secretHash) != sha256.Size {
 			return errors.New("secret hash has wrong size"), true
 		}
 
@@ -716,10 +717,9 @@ func buildRefund(c *rpc.Client, contract []byte, contractTx *wire.MsgTx, feePerK
 	return refundTx, refundFee, nil
 }
 
-func ripemd160Hash(x []byte) []byte {
-	h := ripemd160.New()
-	h.Write(x)
-	return h.Sum(nil)
+func sha256Hash(x []byte) []byte {
+	h := sha256.Sum256(x)
+	return h[:]
 }
 
 func calcFeePerKb(absoluteFee vtcutil.Amount, serializeSize int) float64 {
@@ -732,7 +732,7 @@ func (cmd *initiateCmd) runCommand(c *rpc.Client) error {
 	if err != nil {
 		return err
 	}
-	secretHash := ripemd160Hash(secret[:])
+	secretHash := sha256Hash(secret[:])
 
 	// locktime after 500,000,000 (Tue Nov  5 00:53:20 1985 UTC) is interpreted
 	// as a unix time rather than a block height.
@@ -951,7 +951,7 @@ func (cmd *extractSecretCmd) runOfflineCommand() error {
 			return err
 		}
 		for _, push := range pushes {
-			if bytes.Equal(ripemd160Hash(push), cmd.secretHash) {
+			if bytes.Equal(sha256Hash(push), cmd.secretHash) {
 				fmt.Printf("Secret: %x\n", push)
 				return nil
 			}
@@ -1043,10 +1043,8 @@ func atomicSwapContract(pkhMe, pkhThem *[ripemd160.Size]byte, locktime int64, se
 
 	b.AddOp(txscript.OP_IF) // Normal redeem path
 	{
-		// Require initiator's secret to be known to redeem the output.  A
-		// ripemd160 hash is used here as it is the only shared hash opcode
-		// between decred and vertcoin.
-		b.AddOp(txscript.OP_RIPEMD160)
+		// Require initiator's secret to be known to redeem the output.
+		b.AddOp(txscript.OP_SHA256)
 		b.AddData(secretHash)
 		b.AddOp(txscript.OP_EQUALVERIFY)
 


### PR DESCRIPTION
OP_SHA256 is now available in Decred after the hard fork implementing
it was voted in by stakeholders and the lock-in period after the vote
has completed.  Convert all of the atomic swap tools to use OP_SHA256
instead of the less secure OP_RIPEMD160.

Closes #40.