### PR TITLE
Revert "Switch from RIPEMD160 to SHA256 secret hashes."

### DIFF
--- a/cmd/dcratomicswap/main.go
+++ b/cmd/dcratomicswap/main.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"flag"
@@ -66,7 +65,7 @@ var (
 // initiator can be on either chain.  This tool only deals with creating the
 // Decred transactions for these swaps.  A second tool should be used for the
 // transaction on the other chain.  Any chain can be used so long as it supports
-// OP_SHA256 and OP_CHECKLOCKTIMEVERIFY.
+// OP_RIPEMD160 and OP_CHECKLOCKTIMEVERIFY.
 //
 // Example scenerios using bitcoin as the second chain:
 //
@@ -258,7 +257,7 @@ func run() (err error, showUsage bool) {
 		if err != nil {
 			return errors.New("secret hash must be hex encoded"), true
 		}
-		if len(secretHash) != sha256.Size {
+		if len(secretHash) != ripemd160.Size {
 			return errors.New("secret hash has wrong size"), true
 		}
 
@@ -320,7 +319,7 @@ func run() (err error, showUsage bool) {
 		if err != nil {
 			return errors.New("secret hash must be hex encoded"), true
 		}
-		if len(secretHash) != sha256.Size {
+		if len(secretHash) != ripemd160.Size {
 			return errors.New("secret hash has wrong size"), true
 		}
 
@@ -637,9 +636,10 @@ func buildRefund(ctx context.Context, c pb.WalletServiceClient, contract []byte,
 	return refundTx, refundFee, nil
 }
 
-func sha256Hash(x []byte) []byte {
-	h := sha256.Sum256(x)
-	return h[:]
+func ripemd160Hash(x []byte) []byte {
+	h := ripemd160.New()
+	h.Write(x)
+	return h.Sum(nil)
 }
 
 func calcFeePerKb(absoluteFee dcrutil.Amount, serializeSize int) float64 {
@@ -652,7 +652,7 @@ func (cmd *initiateCmd) runCommand(ctx context.Context, c pb.WalletServiceClient
 	if err != nil {
 		return err
 	}
-	secretHash := sha256Hash(secret[:])
+	secretHash := ripemd160Hash(secret[:])
 
 	// locktime after 500,000,000 (Tue Nov  5 00:53:20 1985 UTC) is interpreted
 	// as a unix time rather than a block height.
@@ -907,7 +907,7 @@ func (cmd *extractSecretCmd) runOfflineCommand() error {
 			return err
 		}
 		for _, push := range pushes {
-			if bytes.Equal(sha256Hash(push), cmd.secretHash) {
+			if bytes.Equal(ripemd160Hash(push), cmd.secretHash) {
 				fmt.Printf("Secret: %x\n", push)
 				return nil
 			}
@@ -999,8 +999,10 @@ func atomicSwapContract(pkhMe, pkhThem *[ripemd160.Size]byte, locktime int64, se
 
 	b.AddOp(txscript.OP_IF) // Normal redeem path
 	{
-		// Require initiator's secret to be known to redeem the output.
-		b.AddOp(txscript.OP_SHA256)
+		// Require initiator's secret to be known to redeem the output.  A
+		// ripemd160 hash is used here as it is the only shared hash opcode
+		// between decred and bitcoin.
+		b.AddOp(txscript.OP_RIPEMD160)
 		b.AddData(secretHash)
 		b.AddOp(txscript.OP_EQUALVERIFY)
 

--- a/cmd/ltcatomicswap/main.go
+++ b/cmd/ltcatomicswap/main.go
@@ -8,7 +8,6 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -52,7 +51,7 @@ var (
 // initiator can be on either chain.  This tool only deals with creating the
 // Litecoin transactions for these swaps.  A second tool should be used for the
 // transaction on the other chain.  Any chain can be used so long as it supports
-// OP_SHA256 and OP_CHECKLOCKTIMEVERIFY.
+// OP_RIPEMD160 and OP_CHECKLOCKTIMEVERIFY.
 //
 // Example scenerios using litecoin as the second chain:
 //
@@ -244,7 +243,7 @@ func run() (err error, showUsage bool) {
 		if err != nil {
 			return errors.New("secret hash must be hex encoded"), true
 		}
-		if len(secretHash) != sha256.Size {
+		if len(secretHash) != ripemd160.Size {
 			return errors.New("secret hash has wrong size"), true
 		}
 
@@ -306,7 +305,7 @@ func run() (err error, showUsage bool) {
 		if err != nil {
 			return errors.New("secret hash must be hex encoded"), true
 		}
-		if len(secretHash) != sha256.Size {
+		if len(secretHash) != ripemd160.Size {
 			return errors.New("secret hash has wrong size"), true
 		}
 
@@ -717,9 +716,10 @@ func buildRefund(c *rpc.Client, contract []byte, contractTx *wire.MsgTx, feePerK
 	return refundTx, refundFee, nil
 }
 
-func sha256Hash(x []byte) []byte {
-	h := sha256.Sum256(x)
-	return h[:]
+func ripemd160Hash(x []byte) []byte {
+	h := ripemd160.New()
+	h.Write(x)
+	return h.Sum(nil)
 }
 
 func calcFeePerKb(absoluteFee ltcutil.Amount, serializeSize int) float64 {
@@ -732,7 +732,7 @@ func (cmd *initiateCmd) runCommand(c *rpc.Client) error {
 	if err != nil {
 		return err
 	}
-	secretHash := sha256Hash(secret[:])
+	secretHash := ripemd160Hash(secret[:])
 
 	// locktime after 500,000,000 (Tue Nov  5 00:53:20 1985 UTC) is interpreted
 	// as a unix time rather than a block height.
@@ -951,7 +951,7 @@ func (cmd *extractSecretCmd) runOfflineCommand() error {
 			return err
 		}
 		for _, push := range pushes {
-			if bytes.Equal(sha256Hash(push), cmd.secretHash) {
+			if bytes.Equal(ripemd160Hash(push), cmd.secretHash) {
 				fmt.Printf("Secret: %x\n", push)
 				return nil
 			}
@@ -1043,8 +1043,10 @@ func atomicSwapContract(pkhMe, pkhThem *[ripemd160.Size]byte, locktime int64, se
 
 	b.AddOp(txscript.OP_IF) // Normal redeem path
 	{
-		// Require initiator's secret to be known to redeem the output.
-		b.AddOp(txscript.OP_SHA256)
+		// Require initiator's secret to be known to redeem the output.  A
+		// ripemd160 hash is used here as it is the only shared hash opcode
+		// between decred and litecoin.
+		b.AddOp(txscript.OP_RIPEMD160)
 		b.AddData(secretHash)
 		b.AddOp(txscript.OP_EQUALVERIFY)
 

--- a/cmd/partatomicswap/main.go
+++ b/cmd/partatomicswap/main.go
@@ -10,7 +10,6 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -54,7 +53,7 @@ var (
 // initiator can be on either chain.  This tool only deals with creating the
 // Bitcoin transactions for these swaps.  A second tool should be used for the
 // transaction on the other chain.  Any chain can be used so long as it supports
-// OP_SHA256 and OP_CHECKLOCKTIMEVERIFY.
+// OP_RIPEMD160 and OP_CHECKLOCKTIMEVERIFY.
 //
 // Example scenerios using bitcoin as the second chain:
 //
@@ -246,7 +245,7 @@ func run() (err error, showUsage bool) {
 		if err != nil {
 			return errors.New("secret hash must be hex encoded"), true
 		}
-		if len(secretHash) != sha256.Size {
+		if len(secretHash) != ripemd160.Size {
 			return errors.New("secret hash has wrong size"), true
 		}
 
@@ -308,7 +307,7 @@ func run() (err error, showUsage bool) {
 		if err != nil {
 			return errors.New("secret hash must be hex encoded"), true
 		}
-		if len(secretHash) != sha256.Size {
+		if len(secretHash) != ripemd160.Size {
 			return errors.New("secret hash has wrong size"), true
 		}
 
@@ -726,9 +725,10 @@ func buildRefund(c *rpc.Client, contract []byte, contractTx *wire.MsgTx, feePerK
 	return refundTx, refundFee, nil
 }
 
-func sha256Hash(x []byte) []byte {
-	h := sha256.Sum256(x)
-	return h[:]
+func ripemd160Hash(x []byte) []byte {
+	h := ripemd160.New()
+	h.Write(x)
+	return h.Sum(nil)
 }
 
 func calcFeePerKb(absoluteFee partutil.Amount, serializeSize int) float64 {
@@ -741,7 +741,7 @@ func (cmd *initiateCmd) runCommand(c *rpc.Client) error {
 	if err != nil {
 		return err
 	}
-	secretHash := sha256Hash(secret[:])
+	secretHash := ripemd160Hash(secret[:])
 
 	// locktime after 500,000,000 (Tue Nov  5 00:53:20 1985 UTC) is interpreted
 	// as a unix time rather than a block height.
@@ -966,13 +966,13 @@ func (cmd *extractSecretCmd) runOfflineCommand() error {
 			return err
 		}
 		for _, push := range pushes {
-			if bytes.Equal(sha256Hash(push), cmd.secretHash) {
+			if bytes.Equal(ripemd160Hash(push), cmd.secretHash) {
 				fmt.Printf("Secret: %x\n", push)
 				return nil
 			}
 		}
 		for _, item := range in.Witness {
-			if bytes.Equal(sha256Hash(item), cmd.secretHash) {
+			if bytes.Equal(ripemd160Hash(item), cmd.secretHash) {
 				fmt.Printf("Secret: %x\n", item)
 				return nil
 			}
@@ -1065,8 +1065,10 @@ func atomicSwapContract(pkhMe, pkhThem *[ripemd160.Size]byte, locktime int64, se
 
 	b.AddOp(txscript.OP_IF) // Normal redeem path
 	{
-		// Require initiator's secret to be known to redeem the output.
-		b.AddOp(txscript.OP_SHA256)
+		// Require initiator's secret to be known to redeem the output.  A
+		// ripemd160 hash is used here as it is the only shared hash opcode
+		// between decred and bitcoin.
+		b.AddOp(txscript.OP_RIPEMD160)
 		b.AddData(secretHash)
 		b.AddOp(txscript.OP_EQUALVERIFY)
 

--- a/cmd/vtcatomicswap/main.go
+++ b/cmd/vtcatomicswap/main.go
@@ -10,7 +10,6 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -54,7 +53,7 @@ var (
 // initiator can be on either chain.  This tool only deals with creating the
 // Vertcoin transactions for these swaps.  A second tool should be used for the
 // transaction on the other chain.  Any chain can be used so long as it supports
-// OP_SHA256 and OP_CHECKLOCKTIMEVERIFY.
+// OP_RIPEMD160 and OP_CHECKLOCKTIMEVERIFY.
 //
 // Example scenerios using Vertcoin as the second chain:
 //
@@ -246,7 +245,7 @@ func run() (err error, showUsage bool) {
 		if err != nil {
 			return errors.New("secret hash must be hex encoded"), true
 		}
-		if len(secretHash) != sha256.Size {
+		if len(secretHash) != ripemd160.Size {
 			return errors.New("secret hash has wrong size"), true
 		}
 
@@ -308,7 +307,7 @@ func run() (err error, showUsage bool) {
 		if err != nil {
 			return errors.New("secret hash must be hex encoded"), true
 		}
-		if len(secretHash) != sha256.Size {
+		if len(secretHash) != ripemd160.Size {
 			return errors.New("secret hash has wrong size"), true
 		}
 
@@ -717,9 +716,10 @@ func buildRefund(c *rpc.Client, contract []byte, contractTx *wire.MsgTx, feePerK
 	return refundTx, refundFee, nil
 }
 
-func sha256Hash(x []byte) []byte {
-	h := sha256.Sum256(x)
-	return h[:]
+func ripemd160Hash(x []byte) []byte {
+	h := ripemd160.New()
+	h.Write(x)
+	return h.Sum(nil)
 }
 
 func calcFeePerKb(absoluteFee vtcutil.Amount, serializeSize int) float64 {
@@ -732,7 +732,7 @@ func (cmd *initiateCmd) runCommand(c *rpc.Client) error {
 	if err != nil {
 		return err
 	}
-	secretHash := sha256Hash(secret[:])
+	secretHash := ripemd160Hash(secret[:])
 
 	// locktime after 500,000,000 (Tue Nov  5 00:53:20 1985 UTC) is interpreted
 	// as a unix time rather than a block height.
@@ -951,7 +951,7 @@ func (cmd *extractSecretCmd) runOfflineCommand() error {
 			return err
 		}
 		for _, push := range pushes {
-			if bytes.Equal(sha256Hash(push), cmd.secretHash) {
+			if bytes.Equal(ripemd160Hash(push), cmd.secretHash) {
 				fmt.Printf("Secret: %x\n", push)
 				return nil
 			}
@@ -1043,8 +1043,10 @@ func atomicSwapContract(pkhMe, pkhThem *[ripemd160.Size]byte, locktime int64, se
 
 	b.AddOp(txscript.OP_IF) // Normal redeem path
 	{
-		// Require initiator's secret to be known to redeem the output.
-		b.AddOp(txscript.OP_SHA256)
+		// Require initiator's secret to be known to redeem the output.  A
+		// ripemd160 hash is used here as it is the only shared hash opcode
+		// between decred and vertcoin.
+		b.AddOp(txscript.OP_RIPEMD160)
 		b.AddData(secretHash)
 		b.AddOp(txscript.OP_EQUALVERIFY)
 


### PR DESCRIPTION
This reverts commit 4c8c7c08f58b596b9501b11fda9e69f51d1d2f7d.

This change is not yet ready until all of the txscript packages have
been updated, otherwise the tools fail to parse the data pushes from
the atomic swap contract.

This change will be reattempted once all of the necessary txscript
updates have been made by maintainers.