### PR TITLE
Switch from RIPEMD160 to SHA256 secret hashes.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -11,7 +11,7 @@
   branch = "master"
   name = "github.com/btcsuite/btcd"
   packages = ["btcec","btcjson","chaincfg","chaincfg/chainhash","rpcclient","txscript","wire"]
-  revision = "4803a8291c92a1d2d41041b942a9a9e37deab065"
+  revision = "2e60448ffcc6bf78332d1fe590260095f554dd78"
 
 [[projects]]
   branch = "master"
@@ -59,31 +59,31 @@
   branch = "master"
   name = "github.com/decred/base58"
   packages = ["."]
-  revision = "b3520e187fa8ebe65eb74245408cf4b83e6a65d3"
+  revision = "a5d313ea54d82327fbdc0fefc817776aa74f44f0"
 
 [[projects]]
   branch = "master"
   name = "github.com/decred/dcrd"
   packages = ["blockchain","blockchain/internal/dbnamespace","blockchain/internal/progresslog","blockchain/stake","blockchain/stake/internal/dbnamespace","blockchain/stake/internal/ticketdb","blockchain/stake/internal/tickettreap","chaincfg","chaincfg/chainec","chaincfg/chainhash","database","dcrec/edwards","dcrec/secp256k1","dcrec/secp256k1/schnorr","dcrutil","txscript","wire"]
-  revision = "d27429061b49d400d06505911a1379b8a8246671"
+  revision = "36c6c7f46e0f06d158ebf84a0548fc51e36bbfab"
 
 [[projects]]
   branch = "master"
   name = "github.com/decred/dcrwallet"
   packages = ["internal/helpers","rpc/walletrpc","wallet/txrules"]
-  revision = "2df4002bce8c540907c9a3e2980fc3e5deeba8f6"
+  revision = "5b0a840f588dde3f52ba002d6b5ef69013cbcd9b"
 
 [[projects]]
   branch = "master"
   name = "github.com/golang/protobuf"
   packages = ["proto","ptypes","ptypes/any","ptypes/duration","ptypes/timestamp"]
-  revision = "ae59567b9aab61b50b2590679a62c3c044030b61"
+  revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
 
 [[projects]]
   branch = "ltcatomicswap"
   name = "github.com/ltcsuite/ltcd"
   packages = ["btcec","btcjson","chaincfg","chaincfg/chainhash","rpcclient","txscript","wire"]
-  revision = "73924b0a232dfbdc943daf7370e5f46bcf5904a6"
+  revision = "07a02d6ef2b1822aad5856cb8cbd2fa6eebb14a8"
   source = "github.com/jrick/btcd"
 
 [[projects]]
@@ -104,7 +104,7 @@
   branch = "master"
   name = "github.com/particl/partsuite_partd"
   packages = ["btcec","btcjson","chaincfg","chaincfg/chainhash","rpcclient","txscript","wire"]
-  revision = "19ee3c9d208d87a11cad892163b54106af847921"
+  revision = "2fa2a4f8167050e4c06457f276fb54ce712ab9b7"
 
 [[projects]]
   branch = "master"
@@ -122,7 +122,7 @@
   branch = "master"
   name = "github.com/vertcoin/vtcd"
   packages = ["btcec","btcjson","chaincfg","chaincfg/chainhash","rpcclient","txscript","wire"]
-  revision = "15387ac36fe71840d251e71f4c81110c793e3b9e"
+  revision = "1c235343bfce9e320613e8a51fe09c84f3d381ca"
 
 [[projects]]
   branch = "master"
@@ -140,37 +140,37 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["pbkdf2","ripemd160","scrypt","ssh/terminal"]
-  revision = "7d9177d70076375b9a59c8fde23d52d9c4a7ecd5"
+  revision = "b3c9a1d25cfbbbab0ff4780b71c4f54e6e92a0de"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context","http2","http2/hpack","idna","internal/timeseries","lex/httplex","trace"]
-  revision = "8351a756f30f1297fe94bbf4b767ec589c6ea6d0"
+  revision = "434ec0c7fe3742c984919a691b2018a6e9694425"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix","windows"]
-  revision = "b6e1ae21643682ce023deb8d152024597b0e9bb4"
+  revision = "810d7000345868fc619eb81f46307107118f4ae1"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
   packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
-  revision = "1cbadb444a806fd9430d14ad08967ed91da4fa0a"
+  revision = "e19ae1496984b1c655b8044a65c0300a3c878dd3"
 
 [[projects]]
   branch = "master"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
-  revision = "1e559d0a00eef8a9a43151db4665280bd8dd5886"
+  revision = "a8101f21cf983e773d0c1133ebc5424792003214"
 
 [[projects]]
   name = "google.golang.org/grpc"
-  packages = [".","codes","connectivity","credentials","grpclb/grpc_lb_v1/messages","grpclog","internal","keepalive","metadata","naming","peer","stats","status","tap","transport"]
-  revision = "f92cdcd7dcdc69e81b2d7b338479a19a8723cfa3"
-  version = "v1.6.0"
+  packages = [".","balancer","balancer/base","balancer/roundrobin","codes","connectivity","credentials","encoding","grpclb/grpc_lb_v1/messages","grpclog","internal","keepalive","metadata","naming","peer","resolver","resolver/dns","resolver/passthrough","stats","status","tap","transport"]
+  revision = "7cea4cc846bcf00cbb27595b07da5de875ef7de9"
+  version = "v1.9.1"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+**NOTICE Jan 10 2018:** The atomic swap contract has been updated to use SHA256
+ secret hashes (instead of RIPEMD160) as it is more secure and has wider
+ compatibility with altcoins.  Old contracts will not be usable by the new tools
+ and vice-versa.  Please rebuild all tools before conducting new atomic swaps.
+
 # Decred cross-chain atomic swapping
 
 This repo contains utilities to manually perform cross-chain atomic swaps

--- a/cmd/btcatomicswap/main.go
+++ b/cmd/btcatomicswap/main.go
@@ -8,6 +8,7 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -51,7 +52,7 @@ var (
 // initiator can be on either chain.  This tool only deals with creating the
 // Bitcoin transactions for these swaps.  A second tool should be used for the
 // transaction on the other chain.  Any chain can be used so long as it supports
-// OP_RIPEMD160 and OP_CHECKLOCKTIMEVERIFY.
+// OP_SHA256 and OP_CHECKLOCKTIMEVERIFY.
 //
 // Example scenerios using bitcoin as the second chain:
 //
@@ -243,7 +244,7 @@ func run() (err error, showUsage bool) {
 		if err != nil {
 			return errors.New("secret hash must be hex encoded"), true
 		}
-		if len(secretHash) != ripemd160.Size {
+		if len(secretHash) != sha256.Size {
 			return errors.New("secret hash has wrong size"), true
 		}
 
@@ -305,7 +306,7 @@ func run() (err error, showUsage bool) {
 		if err != nil {
 			return errors.New("secret hash must be hex encoded"), true
 		}
-		if len(secretHash) != ripemd160.Size {
+		if len(secretHash) != sha256.Size {
 			return errors.New("secret hash has wrong size"), true
 		}
 
@@ -716,10 +717,9 @@ func buildRefund(c *rpc.Client, contract []byte, contractTx *wire.MsgTx, feePerK
 	return refundTx, refundFee, nil
 }
 
-func ripemd160Hash(x []byte) []byte {
-	h := ripemd160.New()
-	h.Write(x)
-	return h.Sum(nil)
+func sha256Hash(x []byte) []byte {
+	h := sha256.Sum256(x)
+	return h[:]
 }
 
 func calcFeePerKb(absoluteFee btcutil.Amount, serializeSize int) float64 {
@@ -732,7 +732,7 @@ func (cmd *initiateCmd) runCommand(c *rpc.Client) error {
 	if err != nil {
 		return err
 	}
-	secretHash := ripemd160Hash(secret[:])
+	secretHash := sha256Hash(secret[:])
 
 	// locktime after 500,000,000 (Tue Nov  5 00:53:20 1985 UTC) is interpreted
 	// as a unix time rather than a block height.
@@ -951,7 +951,7 @@ func (cmd *extractSecretCmd) runOfflineCommand() error {
 			return err
 		}
 		for _, push := range pushes {
-			if bytes.Equal(ripemd160Hash(push), cmd.secretHash) {
+			if bytes.Equal(sha256Hash(push), cmd.secretHash) {
 				fmt.Printf("Secret: %x\n", push)
 				return nil
 			}
@@ -1043,10 +1043,8 @@ func atomicSwapContract(pkhMe, pkhThem *[ripemd160.Size]byte, locktime int64, se
 
 	b.AddOp(txscript.OP_IF) // Normal redeem path
 	{
-		// Require initiator's secret to be known to redeem the output.  A
-		// ripemd160 hash is used here as it is the only shared hash opcode
-		// between decred and bitcoin.
-		b.AddOp(txscript.OP_RIPEMD160)
+		// Require initiator's secret to be known to redeem the output.
+		b.AddOp(txscript.OP_SHA256)
 		b.AddData(secretHash)
 		b.AddOp(txscript.OP_EQUALVERIFY)
 

--- a/cmd/dcratomicswap/main.go
+++ b/cmd/dcratomicswap/main.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"flag"
@@ -44,7 +45,8 @@ const verifyFlags = txscript.ScriptBip16 |
 	txscript.ScriptVerifyCleanStack |
 	txscript.ScriptVerifyCheckLockTimeVerify |
 	txscript.ScriptVerifyCheckSequenceVerify |
-	txscript.ScriptVerifyLowS
+	txscript.ScriptVerifyLowS |
+	txscript.ScriptVerifySHA256
 
 const secretSize = 32
 
@@ -65,7 +67,7 @@ var (
 // initiator can be on either chain.  This tool only deals with creating the
 // Decred transactions for these swaps.  A second tool should be used for the
 // transaction on the other chain.  Any chain can be used so long as it supports
-// OP_RIPEMD160 and OP_CHECKLOCKTIMEVERIFY.
+// OP_SHA256 and OP_CHECKLOCKTIMEVERIFY.
 //
 // Example scenerios using bitcoin as the second chain:
 //
@@ -257,7 +259,7 @@ func run() (err error, showUsage bool) {
 		if err != nil {
 			return errors.New("secret hash must be hex encoded"), true
 		}
-		if len(secretHash) != ripemd160.Size {
+		if len(secretHash) != sha256.Size {
 			return errors.New("secret hash has wrong size"), true
 		}
 
@@ -319,7 +321,7 @@ func run() (err error, showUsage bool) {
 		if err != nil {
 			return errors.New("secret hash must be hex encoded"), true
 		}
-		if len(secretHash) != ripemd160.Size {
+		if len(secretHash) != sha256.Size {
 			return errors.New("secret hash has wrong size"), true
 		}
 
@@ -636,10 +638,9 @@ func buildRefund(ctx context.Context, c pb.WalletServiceClient, contract []byte,
 	return refundTx, refundFee, nil
 }
 
-func ripemd160Hash(x []byte) []byte {
-	h := ripemd160.New()
-	h.Write(x)
-	return h.Sum(nil)
+func sha256Hash(x []byte) []byte {
+	h := sha256.Sum256(x)
+	return h[:]
 }
 
 func calcFeePerKb(absoluteFee dcrutil.Amount, serializeSize int) float64 {
@@ -652,7 +653,7 @@ func (cmd *initiateCmd) runCommand(ctx context.Context, c pb.WalletServiceClient
 	if err != nil {
 		return err
 	}
-	secretHash := ripemd160Hash(secret[:])
+	secretHash := sha256Hash(secret[:])
 
 	// locktime after 500,000,000 (Tue Nov  5 00:53:20 1985 UTC) is interpreted
 	// as a unix time rather than a block height.
@@ -907,7 +908,7 @@ func (cmd *extractSecretCmd) runOfflineCommand() error {
 			return err
 		}
 		for _, push := range pushes {
-			if bytes.Equal(ripemd160Hash(push), cmd.secretHash) {
+			if bytes.Equal(sha256Hash(push), cmd.secretHash) {
 				fmt.Printf("Secret: %x\n", push)
 				return nil
 			}
@@ -999,10 +1000,8 @@ func atomicSwapContract(pkhMe, pkhThem *[ripemd160.Size]byte, locktime int64, se
 
 	b.AddOp(txscript.OP_IF) // Normal redeem path
 	{
-		// Require initiator's secret to be known to redeem the output.  A
-		// ripemd160 hash is used here as it is the only shared hash opcode
-		// between decred and bitcoin.
-		b.AddOp(txscript.OP_RIPEMD160)
+		// Require initiator's secret to be known to redeem the output.
+		b.AddOp(txscript.OP_SHA256)
 		b.AddData(secretHash)
 		b.AddOp(txscript.OP_EQUALVERIFY)
 

--- a/cmd/ltcatomicswap/main.go
+++ b/cmd/ltcatomicswap/main.go
@@ -8,6 +8,7 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -51,7 +52,7 @@ var (
 // initiator can be on either chain.  This tool only deals with creating the
 // Litecoin transactions for these swaps.  A second tool should be used for the
 // transaction on the other chain.  Any chain can be used so long as it supports
-// OP_RIPEMD160 and OP_CHECKLOCKTIMEVERIFY.
+// OP_SHA256 and OP_CHECKLOCKTIMEVERIFY.
 //
 // Example scenerios using litecoin as the second chain:
 //
@@ -243,7 +244,7 @@ func run() (err error, showUsage bool) {
 		if err != nil {
 			return errors.New("secret hash must be hex encoded"), true
 		}
-		if len(secretHash) != ripemd160.Size {
+		if len(secretHash) != sha256.Size {
 			return errors.New("secret hash has wrong size"), true
 		}
 
@@ -305,7 +306,7 @@ func run() (err error, showUsage bool) {
 		if err != nil {
 			return errors.New("secret hash must be hex encoded"), true
 		}
-		if len(secretHash) != ripemd160.Size {
+		if len(secretHash) != sha256.Size {
 			return errors.New("secret hash has wrong size"), true
 		}
 
@@ -716,10 +717,9 @@ func buildRefund(c *rpc.Client, contract []byte, contractTx *wire.MsgTx, feePerK
 	return refundTx, refundFee, nil
 }
 
-func ripemd160Hash(x []byte) []byte {
-	h := ripemd160.New()
-	h.Write(x)
-	return h.Sum(nil)
+func sha256Hash(x []byte) []byte {
+	h := sha256.Sum256(x)
+	return h[:]
 }
 
 func calcFeePerKb(absoluteFee ltcutil.Amount, serializeSize int) float64 {
@@ -732,7 +732,7 @@ func (cmd *initiateCmd) runCommand(c *rpc.Client) error {
 	if err != nil {
 		return err
 	}
-	secretHash := ripemd160Hash(secret[:])
+	secretHash := sha256Hash(secret[:])
 
 	// locktime after 500,000,000 (Tue Nov  5 00:53:20 1985 UTC) is interpreted
 	// as a unix time rather than a block height.
@@ -951,7 +951,7 @@ func (cmd *extractSecretCmd) runOfflineCommand() error {
 			return err
 		}
 		for _, push := range pushes {
-			if bytes.Equal(ripemd160Hash(push), cmd.secretHash) {
+			if bytes.Equal(sha256Hash(push), cmd.secretHash) {
 				fmt.Printf("Secret: %x\n", push)
 				return nil
 			}
@@ -1043,10 +1043,8 @@ func atomicSwapContract(pkhMe, pkhThem *[ripemd160.Size]byte, locktime int64, se
 
 	b.AddOp(txscript.OP_IF) // Normal redeem path
 	{
-		// Require initiator's secret to be known to redeem the output.  A
-		// ripemd160 hash is used here as it is the only shared hash opcode
-		// between decred and litecoin.
-		b.AddOp(txscript.OP_RIPEMD160)
+		// Require initiator's secret to be known to redeem the output.
+		b.AddOp(txscript.OP_SHA256)
 		b.AddData(secretHash)
 		b.AddOp(txscript.OP_EQUALVERIFY)
 

--- a/cmd/vtcatomicswap/main.go
+++ b/cmd/vtcatomicswap/main.go
@@ -10,6 +10,7 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -53,7 +54,7 @@ var (
 // initiator can be on either chain.  This tool only deals with creating the
 // Vertcoin transactions for these swaps.  A second tool should be used for the
 // transaction on the other chain.  Any chain can be used so long as it supports
-// OP_RIPEMD160 and OP_CHECKLOCKTIMEVERIFY.
+// OP_SHA256 and OP_CHECKLOCKTIMEVERIFY.
 //
 // Example scenerios using Vertcoin as the second chain:
 //
@@ -245,7 +246,7 @@ func run() (err error, showUsage bool) {
 		if err != nil {
 			return errors.New("secret hash must be hex encoded"), true
 		}
-		if len(secretHash) != ripemd160.Size {
+		if len(secretHash) != sha256.Size {
 			return errors.New("secret hash has wrong size"), true
 		}
 
@@ -307,7 +308,7 @@ func run() (err error, showUsage bool) {
 		if err != nil {
 			return errors.New("secret hash must be hex encoded"), true
 		}
-		if len(secretHash) != ripemd160.Size {
+		if len(secretHash) != sha256.Size {
 			return errors.New("secret hash has wrong size"), true
 		}
 
@@ -716,10 +717,9 @@ func buildRefund(c *rpc.Client, contract []byte, contractTx *wire.MsgTx, feePerK
 	return refundTx, refundFee, nil
 }
 
-func ripemd160Hash(x []byte) []byte {
-	h := ripemd160.New()
-	h.Write(x)
-	return h.Sum(nil)
+func sha256Hash(x []byte) []byte {
+	h := sha256.Sum256(x)
+	return h[:]
 }
 
 func calcFeePerKb(absoluteFee vtcutil.Amount, serializeSize int) float64 {
@@ -732,7 +732,7 @@ func (cmd *initiateCmd) runCommand(c *rpc.Client) error {
 	if err != nil {
 		return err
 	}
-	secretHash := ripemd160Hash(secret[:])
+	secretHash := sha256Hash(secret[:])
 
 	// locktime after 500,000,000 (Tue Nov  5 00:53:20 1985 UTC) is interpreted
 	// as a unix time rather than a block height.
@@ -951,7 +951,7 @@ func (cmd *extractSecretCmd) runOfflineCommand() error {
 			return err
 		}
 		for _, push := range pushes {
-			if bytes.Equal(ripemd160Hash(push), cmd.secretHash) {
+			if bytes.Equal(sha256Hash(push), cmd.secretHash) {
 				fmt.Printf("Secret: %x\n", push)
 				return nil
 			}
@@ -1043,10 +1043,8 @@ func atomicSwapContract(pkhMe, pkhThem *[ripemd160.Size]byte, locktime int64, se
 
 	b.AddOp(txscript.OP_IF) // Normal redeem path
 	{
-		// Require initiator's secret to be known to redeem the output.  A
-		// ripemd160 hash is used here as it is the only shared hash opcode
-		// between decred and vertcoin.
-		b.AddOp(txscript.OP_RIPEMD160)
+		// Require initiator's secret to be known to redeem the output.
+		b.AddOp(txscript.OP_SHA256)
 		b.AddData(secretHash)
 		b.AddOp(txscript.OP_EQUALVERIFY)
 


### PR DESCRIPTION
OP_SHA256 is now available in Decred after the hard fork implementing
it was voted in by stakeholders and the lock-in period after the vote
has completed.  Convert all of the atomic swap tools to use OP_SHA256
instead of the less secure OP_RIPEMD160.

Closes #40.