### PR TITLE
Zcoin atomic swap to be merged

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -59,19 +59,19 @@
   branch = "master"
   name = "github.com/decred/base58"
   packages = ["."]
-  revision = "56c501706f00d9e1cfacee19a27117e12da24734"
+  revision = "229e657bc9be5d592855a910428907f851950ed5"
 
 [[projects]]
   branch = "master"
   name = "github.com/decred/dcrd"
-  packages = ["blockchain","blockchain/internal/dbnamespace","blockchain/internal/progresslog","blockchain/stake","blockchain/stake/internal/dbnamespace","blockchain/stake/internal/ticketdb","blockchain/stake/internal/tickettreap","chaincfg","chaincfg/chainec","chaincfg/chainhash","database","dcrec/edwards","dcrec/secp256k1","dcrec/secp256k1/schnorr","dcrjson","dcrutil","txscript","wire"]
-  revision = "27fad14a1d106fdb5abd7bd7a960f87b93b254f7"
+  packages = ["blockchain","blockchain/internal/dbnamespace","blockchain/internal/progresslog","blockchain/stake","blockchain/stake/internal/dbnamespace","blockchain/stake/internal/ticketdb","blockchain/stake/internal/tickettreap","chaincfg","chaincfg/chainec","chaincfg/chainhash","database","dcrec/edwards","dcrec/secp256k1","dcrec/secp256k1/schnorr","dcrutil","txscript","wire"]
+  revision = "60c7bc0e10b438ed9e52af039988a8c8479475fb"
 
 [[projects]]
   branch = "master"
   name = "github.com/decred/dcrwallet"
   packages = ["internal/helpers","rpc/walletrpc","wallet/txrules"]
-  revision = "87b1f9a230dfa916a4501c2360e741081ca035a0"
+  revision = "1dc40f82683013a2111dd6bcfbd22d3dd219bc34"
 
 [[projects]]
   branch = "master"
@@ -158,19 +158,19 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["pbkdf2","ripemd160","scrypt","ssh/terminal"]
-  revision = "c7dcf104e3a7a1417abc0230cb0d5240d764159d"
+  revision = "91a49db82a88618983a78a06c1cbd4e00ab749ab"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context","http2","http2/hpack","idna","internal/timeseries","lex/httplex","trace"]
-  revision = "ae89d30ce0c63142b652837da33d782e2b0a9b25"
+  revision = "cbe0f9307d0156177f9dd5dc85da1a31abc5f2fb"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix","windows"]
-  revision = "7dca6fe1f43775aa6d1334576870ff63f978f539"
+  revision = "f6cff0780e542efa0c8e864dc8fa522808f6a598"
 
 [[projects]]
   name = "golang.org/x/text"
@@ -182,7 +182,7 @@
   branch = "master"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
-  revision = "df60624c1e9b9d2973e889c7a1cff73155da81c4"
+  revision = "2d9486acae19cf9bd0c093d7dc236a323726a9e4"
 
 [[projects]]
   name = "google.golang.org/grpc"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -11,7 +11,7 @@
   branch = "master"
   name = "github.com/btcsuite/btcd"
   packages = ["btcec","btcjson","chaincfg","chaincfg/chainhash","rpcclient","txscript","wire"]
-  revision = "2e60448ffcc6bf78332d1fe590260095f554dd78"
+  revision = "2be2f12b358dc57d70b8f501b00be450192efbc3"
 
 [[projects]]
   branch = "master"
@@ -59,31 +59,31 @@
   branch = "master"
   name = "github.com/decred/base58"
   packages = ["."]
-  revision = "a5d313ea54d82327fbdc0fefc817776aa74f44f0"
+  revision = "56c501706f00d9e1cfacee19a27117e12da24734"
 
 [[projects]]
   branch = "master"
   name = "github.com/decred/dcrd"
-  packages = ["blockchain","blockchain/internal/dbnamespace","blockchain/internal/progresslog","blockchain/stake","blockchain/stake/internal/dbnamespace","blockchain/stake/internal/ticketdb","blockchain/stake/internal/tickettreap","chaincfg","chaincfg/chainec","chaincfg/chainhash","database","dcrec/edwards","dcrec/secp256k1","dcrec/secp256k1/schnorr","dcrutil","txscript","wire"]
-  revision = "36c6c7f46e0f06d158ebf84a0548fc51e36bbfab"
+  packages = ["blockchain","blockchain/internal/dbnamespace","blockchain/internal/progresslog","blockchain/stake","blockchain/stake/internal/dbnamespace","blockchain/stake/internal/ticketdb","blockchain/stake/internal/tickettreap","chaincfg","chaincfg/chainec","chaincfg/chainhash","database","dcrec/edwards","dcrec/secp256k1","dcrec/secp256k1/schnorr","dcrjson","dcrutil","txscript","wire"]
+  revision = "27fad14a1d106fdb5abd7bd7a960f87b93b254f7"
 
 [[projects]]
   branch = "master"
   name = "github.com/decred/dcrwallet"
   packages = ["internal/helpers","rpc/walletrpc","wallet/txrules"]
-  revision = "d30a472733d50937564612165fff1387921d3eaf"
+  revision = "87b1f9a230dfa916a4501c2360e741081ca035a0"
 
 [[projects]]
   branch = "master"
   name = "github.com/golang/protobuf"
   packages = ["proto","ptypes","ptypes/any","ptypes/duration","ptypes/timestamp"]
-  revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
+  revision = "bbd03ef6da3a115852eaf24c8a1c46aeb39aa175"
 
 [[projects]]
   branch = "ltcatomicswap"
   name = "github.com/ltcsuite/ltcd"
   packages = ["btcec","btcjson","chaincfg","chaincfg/chainhash","rpcclient","txscript","wire"]
-  revision = "07a02d6ef2b1822aad5856cb8cbd2fa6eebb14a8"
+  revision = "941d1c922dfd3d5bedd889dcbcf818db37aab0e2"
   source = "github.com/jrick/btcd"
 
 [[projects]]
@@ -104,7 +104,7 @@
   branch = "master"
   name = "github.com/particl/partsuite_partd"
   packages = ["btcec","btcjson","chaincfg","chaincfg/chainhash","rpcclient","txscript","wire"]
-  revision = "2fa2a4f8167050e4c06457f276fb54ce712ab9b7"
+  revision = "ae651ccc82938a86c4ea059fc56c305c1e074240"
 
 [[projects]]
   branch = "master"
@@ -122,7 +122,7 @@
   branch = "master"
   name = "github.com/vertcoin/vtcd"
   packages = ["btcec","btcjson","chaincfg","chaincfg/chainhash","rpcclient","txscript","wire"]
-  revision = "1c235343bfce9e320613e8a51fe09c84f3d381ca"
+  revision = "e703c22063ac06bc1a776d60c9f5b60b6bed17c8"
 
 [[projects]]
   branch = "master"
@@ -140,7 +140,7 @@
   branch = "master"
   name = "github.com/zcoinofficial/xzcd"
   packages = ["btcec","btcjson","chaincfg","chaincfg/chainhash","rpcclient","txscript","wire"]
-  revision = "b47c7174175d9d05d3887249ec35fa1776b1d2a2"
+  revision = "ae307d1ae9070c5434a6a203992db0ad35712e96"
 
 [[projects]]
   branch = "master"
@@ -158,37 +158,37 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["pbkdf2","ripemd160","scrypt","ssh/terminal"]
-  revision = "13931e22f9e72ea58bb73048bc752b48c6d4d4ac"
+  revision = "c7dcf104e3a7a1417abc0230cb0d5240d764159d"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context","http2","http2/hpack","idna","internal/timeseries","lex/httplex","trace"]
-  revision = "5ccada7d0a7ba9aeb5d3aca8d3501b4c2a509fec"
+  revision = "ae89d30ce0c63142b652837da33d782e2b0a9b25"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix","windows"]
-  revision = "fff93fa7cd278d84afc205751523809c464168ab"
+  revision = "7dca6fe1f43775aa6d1334576870ff63f978f539"
 
 [[projects]]
-  branch = "master"
   name = "golang.org/x/text"
   packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
-  revision = "e19ae1496984b1c655b8044a65c0300a3c878dd3"
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
 
 [[projects]]
   branch = "master"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
-  revision = "a8101f21cf983e773d0c1133ebc5424792003214"
+  revision = "df60624c1e9b9d2973e889c7a1cff73155da81c4"
 
 [[projects]]
   name = "google.golang.org/grpc"
-  packages = [".","balancer","balancer/base","balancer/roundrobin","codes","connectivity","credentials","encoding","grpclb/grpc_lb_v1/messages","grpclog","internal","keepalive","metadata","naming","peer","resolver","resolver/dns","resolver/passthrough","stats","status","tap","transport"]
-  revision = "7cea4cc846bcf00cbb27595b07da5de875ef7de9"
-  version = "v1.9.1"
+  packages = [".","balancer","balancer/base","balancer/roundrobin","codes","connectivity","credentials","encoding","encoding/proto","grpclb/grpc_lb_v1/messages","grpclog","internal","keepalive","metadata","naming","peer","resolver","resolver/dns","resolver/passthrough","stats","status","tap","transport"]
+  revision = "8e4536a86ab602859c20df5ebfd0bd4228d08655"
+  version = "v1.10.0"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -71,7 +71,7 @@
   branch = "master"
   name = "github.com/decred/dcrwallet"
   packages = ["internal/helpers","rpc/walletrpc","wallet/txrules"]
-  revision = "5b0a840f588dde3f52ba002d6b5ef69013cbcd9b"
+  revision = "d30a472733d50937564612165fff1387921d3eaf"
 
 [[projects]]
   branch = "master"
@@ -138,21 +138,39 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/zcoinofficial/xzcd"
+  packages = ["btcec","btcjson","chaincfg","chaincfg/chainhash","rpcclient","txscript","wire"]
+  revision = "b47c7174175d9d05d3887249ec35fa1776b1d2a2"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/zcoinofficial/xzcutil"
+  packages = [".","base58","bech32"]
+  revision = "ca7c84e1d45c50576b352b6dd22f0547b0b56c30"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/zcoinofficial/xzcwallet"
+  packages = ["wallet/txrules"]
+  revision = "fe84e6e188b8a4d350109646c084d0fb8c147fae"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/crypto"
   packages = ["pbkdf2","ripemd160","scrypt","ssh/terminal"]
-  revision = "b3c9a1d25cfbbbab0ff4780b71c4f54e6e92a0de"
+  revision = "13931e22f9e72ea58bb73048bc752b48c6d4d4ac"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context","http2","http2/hpack","idna","internal/timeseries","lex/httplex","trace"]
-  revision = "434ec0c7fe3742c984919a691b2018a6e9694425"
+  revision = "5ccada7d0a7ba9aeb5d3aca8d3501b4c2a509fec"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix","windows"]
-  revision = "810d7000345868fc619eb81f46307107118f4ae1"
+  revision = "fff93fa7cd278d84afc205751523809c464168ab"
 
 [[projects]]
   branch = "master"
@@ -175,6 +193,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "cf9373df2e658d00b7f8ca09ac087f26f56ee593ab786b80d8166efd3720f171"
+  inputs-digest = "3ec7a1fde3d2b2f1dc9aa465d2bfcb54d566aa8323a5816889940639b8f2087e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -42,6 +42,18 @@
   name = "github.com/decred/dcrwallet"
 
 [[constraint]]
+  branch = "master"
+  name = "github.com/viacoin/viad"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/viacoin/viautil"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/viacoin/viawallet"
+
+[[constraint]]
   branch = "ltcatomicswap"
   name = "github.com/ltcsuite/ltcd"
   source = "github.com/jrick/btcd"
@@ -87,6 +99,27 @@
 [[constraint]]
   branch = "master"
   name = "github.com/particl/partsuite_partwallet"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/DesWurstes/btcd"
+
+[[constraint]]
+  # Further commits have not been tested with bchatomicswap yet.
+  revision = "223045ec4d9ef2fcc7c6ed62f9a8ed80ac9bdf58"
+  name = "github.com/cpacia/bchutil"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/wakiyamap/monad"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/wakiyamap/monautil"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/wakiyamap/monawallet"
 
 [[constraint]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -87,3 +87,15 @@
 [[constraint]]
   branch = "master"
   name = "github.com/particl/partsuite_partwallet"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/zcoinofficial/xzcd"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/zcoinofficial/xzcutil"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/zcoinofficial/xzcwallet"

--- a/cmd/xzcatomicswap/main.go
+++ b/cmd/xzcatomicswap/main.go
@@ -1,0 +1,1106 @@
+// Copyright (c) 2017 The Decred developers
+// Copyright (c) 2018 The Zcoin developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/zcoinofficial/xzcd/chaincfg"
+	"github.com/zcoinofficial/xzcd/chaincfg/chainhash"
+	rpc "github.com/zcoinofficial/xzcd/rpcclient"
+	"github.com/zcoinofficial/xzcd/txscript"
+	"github.com/zcoinofficial/xzcd/wire"
+	xzcutil "github.com/zcoinofficial/xzcutil"
+	"github.com/zcoinofficial/xzcwallet/wallet/txrules"
+	"golang.org/x/crypto/ripemd160"
+)
+
+const verify = true
+
+const secretSize = 32
+
+const txVersion = 2
+
+var (
+	chainParams = &chaincfg.MainNetParams
+)
+
+var (
+	flagset     = flag.NewFlagSet("", flag.ExitOnError)
+	connectFlag = flagset.String("s", "localhost", "host[:port] of Zcoin Core wallet RPC server")
+	rpcuserFlag = flagset.String("rpcuser", "", "username for wallet RPC authentication")
+	rpcpassFlag = flagset.String("rpcpass", "", "password for wallet RPC authentication")
+	testnetFlag = flagset.Bool("testnet", false, "use testnet network")
+)
+
+// There are two directions that the atomic swap can be performed, as the
+// initiator can be on either chain.  This tool only deals with creating the
+// Zcoin transactions for these swaps.  A second tool should be used for the
+// transaction on the other chain.  Any chain can be used so long as it supports
+// OP_SHA256 and OP_CHECKLOCKTIMEVERIFY.
+//
+// Example scenerios using zcoin as the second chain:
+//
+// Scenerio 1:
+//   cp1 initiates (dcr)
+//   cp2 participates with cp1 H(S) (xzc)
+//   cp1 redeems xzc revealing S
+//     - must verify H(S) in contract is hash of known secret
+//   cp2 redeems dcr with S
+//
+// Scenerio 2:
+//   cp1 initiates (xzc)
+//   cp2 participates with cp1 H(S) (dcr)
+//   cp1 redeems dcr revealing S
+//     - must verify H(S) in contract is hash of known secret
+//   cp2 redeems xzc with S
+
+func init() {
+	flagset.Usage = func() {
+		fmt.Println("Usage: xzcatomicswap [flags] cmd [cmd args]")
+		fmt.Println()
+		fmt.Println("Commands:")
+		fmt.Println("  initiate <participant address> <amount>")
+		fmt.Println("  participate <initiator address> <amount> <secret hash>")
+		fmt.Println("  redeem <contract> <contract transaction> <secret>")
+		fmt.Println("  refund <contract> <contract transaction>")
+		fmt.Println("  extractsecret <redemption transaction> <secret hash>")
+		fmt.Println("  auditcontract <contract> <contract transaction>")
+		fmt.Println()
+		fmt.Println("Flags:")
+		flagset.PrintDefaults()
+	}
+}
+
+type command interface {
+	runCommand(*rpc.Client) error
+}
+
+// offline commands don't require wallet RPC.
+type offlineCommand interface {
+	command
+	runOfflineCommand() error
+}
+
+type initiateCmd struct {
+	cp2Addr *xzcutil.AddressPubKeyHash
+	amount  xzcutil.Amount
+}
+
+type participateCmd struct {
+	cp1Addr    *xzcutil.AddressPubKeyHash
+	amount     xzcutil.Amount
+	secretHash []byte
+}
+
+type redeemCmd struct {
+	contract   []byte
+	contractTx *wire.MsgTx
+	secret     []byte
+}
+
+type refundCmd struct {
+	contract   []byte
+	contractTx *wire.MsgTx
+}
+
+type extractSecretCmd struct {
+	redemptionTx *wire.MsgTx
+	secretHash   []byte
+}
+
+type auditContractCmd struct {
+	contract   []byte
+	contractTx *wire.MsgTx
+}
+
+func main() {
+	err, showUsage := run()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+	}
+	if showUsage {
+		flagset.Usage()
+	}
+	if err != nil || showUsage {
+		os.Exit(1)
+	}
+}
+
+func checkCmdArgLength(args []string, required int) (nArgs int) {
+	if len(args) < required {
+		return 0
+	}
+	for i, arg := range args[:required] {
+		if len(arg) != 1 && strings.HasPrefix(arg, "-") {
+			return i
+		}
+	}
+	return required
+}
+
+func run() (err error, showUsage bool) {
+	flagset.Parse(os.Args[1:])
+	args := flagset.Args()
+	if len(args) == 0 {
+		return nil, true
+	}
+	cmdArgs := 0
+	switch args[0] {
+	case "initiate":
+		cmdArgs = 2
+	case "participate":
+		cmdArgs = 3
+	case "redeem":
+		cmdArgs = 3
+	case "refund":
+		cmdArgs = 2
+	case "extractsecret":
+		cmdArgs = 2
+	case "auditcontract":
+		cmdArgs = 2
+	default:
+		return fmt.Errorf("unknown command %v", args[0]), true
+	}
+	nArgs := checkCmdArgLength(args[1:], cmdArgs)
+	flagset.Parse(args[1+nArgs:])
+	if nArgs < cmdArgs {
+		return fmt.Errorf("%s: too few arguments", args[0]), true
+	}
+	if flagset.NArg() != 0 {
+		return fmt.Errorf("unexpected argument: %s", flagset.Arg(0)), true
+	}
+
+	if *testnetFlag {
+		chainParams = &chaincfg.TestNet3Params
+	}
+
+	var cmd command
+	switch args[0] {
+	case "initiate":
+		cp2Addr, err := xzcutil.DecodeAddress(args[1], chainParams)
+		if err != nil {
+			return fmt.Errorf("failed to decode participant address: %v", err), true
+		}
+		if !cp2Addr.IsForNet(chainParams) {
+			return fmt.Errorf("participant address is not "+
+				"intended for use on %v", chainParams.Name), true
+		}
+		cp2AddrP2PKH, ok := cp2Addr.(*xzcutil.AddressPubKeyHash)
+		if !ok {
+			return errors.New("participant address is not P2PKH"), true
+		}
+
+		amountF64, err := strconv.ParseFloat(args[2], 64)
+		if err != nil {
+			return fmt.Errorf("failed to decode amount: %v", err), true
+		}
+		amount, err := xzcutil.NewAmount(amountF64)
+		if err != nil {
+			return err, true
+		}
+
+		cmd = &initiateCmd{cp2Addr: cp2AddrP2PKH, amount: amount}
+
+	case "participate":
+		cp1Addr, err := xzcutil.DecodeAddress(args[1], chainParams)
+		if err != nil {
+			return fmt.Errorf("failed to decode initiator address: %v", err), true
+		}
+		if !cp1Addr.IsForNet(chainParams) {
+			return fmt.Errorf("initiator address is not "+
+				"intended for use on %v", chainParams.Name), true
+		}
+		cp1AddrP2PKH, ok := cp1Addr.(*xzcutil.AddressPubKeyHash)
+		if !ok {
+			return errors.New("initiator address is not P2PKH"), true
+		}
+
+		amountF64, err := strconv.ParseFloat(args[2], 64)
+		if err != nil {
+			return fmt.Errorf("failed to decode amount: %v", err), true
+		}
+		amount, err := xzcutil.NewAmount(amountF64)
+		if err != nil {
+			return err, true
+		}
+
+		secretHash, err := hex.DecodeString(args[3])
+		if err != nil {
+			return errors.New("secret hash must be hex encoded"), true
+		}
+		if len(secretHash) != sha256.Size {
+			return errors.New("secret hash has wrong size"), true
+		}
+
+		cmd = &participateCmd{cp1Addr: cp1AddrP2PKH, amount: amount, secretHash: secretHash}
+
+	case "redeem":
+		contract, err := hex.DecodeString(args[1])
+		if err != nil {
+			return fmt.Errorf("failed to decode contract: %v", err), true
+		}
+
+		contractTxBytes, err := hex.DecodeString(args[2])
+		if err != nil {
+			return fmt.Errorf("failed to decode contract transaction: %v", err), true
+		}
+		var contractTx wire.MsgTx
+		err = contractTx.Deserialize(bytes.NewReader(contractTxBytes))
+		if err != nil {
+			return fmt.Errorf("failed to decode contract transaction: %v", err), true
+		}
+
+		secret, err := hex.DecodeString(args[3])
+		if err != nil {
+			return fmt.Errorf("failed to decode secret: %v", err), true
+		}
+
+		cmd = &redeemCmd{contract: contract, contractTx: &contractTx, secret: secret}
+
+	case "refund":
+		contract, err := hex.DecodeString(args[1])
+		if err != nil {
+			return fmt.Errorf("failed to decode contract: %v", err), true
+		}
+
+		contractTxBytes, err := hex.DecodeString(args[2])
+		if err != nil {
+			return fmt.Errorf("failed to decode contract transaction: %v", err), true
+		}
+		var contractTx wire.MsgTx
+		err = contractTx.Deserialize(bytes.NewReader(contractTxBytes))
+		if err != nil {
+			return fmt.Errorf("failed to decode contract transaction: %v", err), true
+		}
+
+		cmd = &refundCmd{contract: contract, contractTx: &contractTx}
+
+	case "extractsecret":
+		redemptionTxBytes, err := hex.DecodeString(args[1])
+		if err != nil {
+			return fmt.Errorf("failed to decode redemption transaction: %v", err), true
+		}
+		var redemptionTx wire.MsgTx
+		err = redemptionTx.Deserialize(bytes.NewReader(redemptionTxBytes))
+		if err != nil {
+			return fmt.Errorf("failed to decode redemption transaction: %v", err), true
+		}
+
+		secretHash, err := hex.DecodeString(args[2])
+		if err != nil {
+			return errors.New("secret hash must be hex encoded"), true
+		}
+		if len(secretHash) != sha256.Size {
+			return errors.New("secret hash has wrong size"), true
+		}
+
+		cmd = &extractSecretCmd{redemptionTx: &redemptionTx, secretHash: secretHash}
+
+	case "auditcontract":
+		contract, err := hex.DecodeString(args[1])
+		if err != nil {
+			return fmt.Errorf("failed to decode contract: %v", err), true
+		}
+
+		contractTxBytes, err := hex.DecodeString(args[2])
+		if err != nil {
+			return fmt.Errorf("failed to decode contract transaction: %v", err), true
+		}
+		var contractTx wire.MsgTx
+		err = contractTx.Deserialize(bytes.NewReader(contractTxBytes))
+		if err != nil {
+			return fmt.Errorf("failed to decode contract transaction: %v", err), true
+		}
+
+		cmd = &auditContractCmd{contract: contract, contractTx: &contractTx}
+	}
+
+	// Offline commands don't need to talk to the wallet.
+	if cmd, ok := cmd.(offlineCommand); ok {
+		return cmd.runOfflineCommand(), false
+	}
+
+	connect, err := normalizeAddress(*connectFlag, walletPort(chainParams))
+	if err != nil {
+		return fmt.Errorf("wallet server address: %v", err), true
+	}
+
+	connConfig := &rpc.ConnConfig{
+		Host:         connect,
+		User:         *rpcuserFlag,
+		Pass:         *rpcpassFlag,
+		DisableTLS:   true,
+		HTTPPostMode: true,
+	}
+	client, err := rpc.New(connConfig, nil)
+	if err != nil {
+		return fmt.Errorf("rpc connect: %v", err), false
+	}
+	defer func() {
+		client.Shutdown()
+		client.WaitForShutdown()
+	}()
+
+	err = cmd.runCommand(client)
+	return err, false
+}
+
+func normalizeAddress(addr string, defaultPort string) (hostport string, err error) {
+	host, port, origErr := net.SplitHostPort(addr)
+	if origErr == nil {
+		return net.JoinHostPort(host, port), nil
+	}
+	addr = net.JoinHostPort(addr, defaultPort)
+	_, _, err = net.SplitHostPort(addr)
+	if err != nil {
+		return "", origErr
+	}
+	return addr, nil
+}
+
+func walletPort(params *chaincfg.Params) string {
+	switch params {
+	case &chaincfg.MainNetParams:
+		return "8888"
+	case &chaincfg.TestNet3Params:
+		return "18888"
+	default:
+		return ""
+	}
+}
+
+// createSig creates and returns the serialized raw signature and compressed
+// pubkey for a transaction input signature.  Due to limitations of the Zcoin
+// Core RPC API, this requires dumping a private key and signing in the client,
+// rather than letting the wallet sign.
+func createSig(tx *wire.MsgTx, idx int, pkScript []byte, addr xzcutil.Address,
+	c *rpc.Client) (sig, pubkey []byte, err error) {
+
+	wif, err := c.DumpPrivKey(addr)
+	if err != nil {
+		return nil, nil, err
+	}
+	sig, err = txscript.RawTxInSignature(tx, idx, pkScript, txscript.SigHashAll, wif.PrivKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	return sig, wif.PrivKey.PubKey().SerializeCompressed(), nil
+}
+
+// fundRawTransaction calls the fundrawtransaction JSON-RPC method.  It is
+// implemented manually as client support is currently missing from the
+// xzcd/rpcclient package.
+func fundRawTransaction(c *rpc.Client, tx *wire.MsgTx, feePerKb xzcutil.Amount) (fundedTx *wire.MsgTx, fee xzcutil.Amount, err error) {
+	var buf bytes.Buffer
+	buf.Grow(tx.SerializeSize())
+	tx.Serialize(&buf)
+	param0, err := json.Marshal(hex.EncodeToString(buf.Bytes()))
+	if err != nil {
+		return nil, 0, err
+	}
+	param1, err := json.Marshal(struct {
+		FeeRate float64 `json:"feeRate"`
+	}{
+		FeeRate: feePerKb.ToXZC(),
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	params := []json.RawMessage{param0, param1}
+	rawResp, err := c.RawRequest("fundrawtransaction", params)
+	if err != nil {
+		return nil, 0, err
+	}
+	var resp struct {
+		Hex       string  `json:"hex"`
+		Fee       float64 `json:"fee"`
+		ChangePos float64 `json:"changepos"`
+	}
+	err = json.Unmarshal(rawResp, &resp)
+	if err != nil {
+		return nil, 0, err
+	}
+	fundedTxBytes, err := hex.DecodeString(resp.Hex)
+	if err != nil {
+		return nil, 0, err
+	}
+	fundedTx = &wire.MsgTx{}
+	err = fundedTx.Deserialize(bytes.NewReader(fundedTxBytes))
+	if err != nil {
+		return nil, 0, err
+	}
+	feeAmount, err := xzcutil.NewAmount(resp.Fee)
+	if err != nil {
+		return nil, 0, err
+	}
+	return fundedTx, feeAmount, nil
+}
+
+// getFeePerKb queries the wallet for the transaction relay fee/kB to use and
+// the minimum mempool relay fee.  It first tries to get the user-set fee in the
+// wallet.  If unset, it attempts to find an estimate using estimatefee 6.  If
+// both of these fail, it falls back to mempool relay fee policy.
+func getFeePerKb(c *rpc.Client) (useFee, relayFee xzcutil.Amount, err error) {
+	info, err := c.GetInfo()
+	if err != nil {
+		return 0, 0, fmt.Errorf("getinfo: %v", err)
+	}
+	relayFee, err = xzcutil.NewAmount(info.RelayFee)
+	if err != nil {
+		return 0, 0, err
+	}
+	maxFee := info.PaytxFee
+	if info.PaytxFee != 0 {
+		if info.RelayFee > maxFee {
+			maxFee = info.RelayFee
+		}
+		useFee, err = xzcutil.NewAmount(maxFee)
+		return useFee, relayFee, err
+	}
+
+	params := []json.RawMessage{[]byte("6")}
+	estimateRawResp, err := c.RawRequest("estimatefee", params)
+	if err != nil {
+		return 0, 0, err
+	}
+	var estimateResp float64 = -1
+	err = json.Unmarshal(estimateRawResp, &estimateResp)
+	if err == nil && estimateResp != -1 {
+		useFee, err = xzcutil.NewAmount(estimateResp)
+		if relayFee > useFee {
+			useFee = relayFee
+		}
+		return useFee, relayFee, err
+	}
+
+	fmt.Println("warning: falling back to mempool relay fee policy")
+	useFee, err = xzcutil.NewAmount(info.RelayFee)
+	return useFee, relayFee, err
+}
+
+// getRawChangeAddress calls the getrawchangeaddress JSON-RPC method.  It is
+// implemented manually as the rpcclient implementation always passes the
+// account parameter which was removed in Bitcoin Core 0.15.
+func getRawChangeAddress(c *rpc.Client) (xzcutil.Address, error) {
+	rawResp, err := c.RawRequest("getrawchangeaddress", nil)
+	if err != nil {
+		return nil, err
+	}
+	var addrStr string
+	err = json.Unmarshal(rawResp, &addrStr)
+	if err != nil {
+		return nil, err
+	}
+	addr, err := xzcutil.DecodeAddress(addrStr, chainParams)
+	if err != nil {
+		return nil, err
+	}
+	if !addr.IsForNet(chainParams) {
+		return nil, fmt.Errorf("address %v is not intended for use on %v",
+			addrStr, chainParams.Name)
+	}
+	return addr, nil
+}
+
+func promptPublishTx(c *rpc.Client, tx *wire.MsgTx, name string) error {
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		fmt.Printf("Publish %s transaction? [y/N] ", name)
+		answer, err := reader.ReadString('\n')
+		if err != nil {
+			return err
+		}
+		answer = strings.TrimSpace(strings.ToLower(answer))
+
+		switch answer {
+		case "y", "yes":
+		case "n", "no", "":
+			return nil
+		default:
+			fmt.Println("please answer y or n")
+			continue
+		}
+
+		txHash, err := c.SendRawTransaction(tx, false)
+		if err != nil {
+			return fmt.Errorf("sendrawtransaction: %v", err)
+		}
+		fmt.Printf("Published %s transaction (%v)\n", name, txHash)
+		return nil
+	}
+}
+
+// contractArgs specifies the common parameters used to create the initiator's
+// and participant's contract.
+type contractArgs struct {
+	them       *xzcutil.AddressPubKeyHash
+	amount     xzcutil.Amount
+	locktime   int64
+	secretHash []byte
+}
+
+// builtContract houses the details regarding a contract and the contract
+// payment transaction, as well as the transaction to perform a refund.
+type builtContract struct {
+	contract       []byte
+	contractP2SH   xzcutil.Address
+	contractTxHash *chainhash.Hash
+	contractTx     *wire.MsgTx
+	contractFee    xzcutil.Amount
+	refundTx       *wire.MsgTx
+	refundFee      xzcutil.Amount
+}
+
+// buildContract creates a contract for the parameters specified in args, using
+// wallet RPC to generate an internal address to redeem the refund and to sign
+// the payment to the contract transaction.
+func buildContract(c *rpc.Client, args *contractArgs) (*builtContract, error) {
+	refundAddr, err := getRawChangeAddress(c)
+	if err != nil {
+		return nil, fmt.Errorf("getrawchangeaddress: %v", err)
+	}
+	refundAddrH, ok := refundAddr.(interface {
+		Hash160() *[ripemd160.Size]byte
+	})
+	if !ok {
+		return nil, errors.New("unable to create hash160 from change address")
+	}
+
+	contract, err := atomicSwapContract(refundAddrH.Hash160(), args.them.Hash160(),
+		args.locktime, args.secretHash)
+	if err != nil {
+		return nil, err
+	}
+	contractP2SH, err := xzcutil.NewAddressScriptHash(contract, chainParams)
+	if err != nil {
+		return nil, err
+	}
+	contractP2SHPkScript, err := txscript.PayToAddrScript(contractP2SH)
+	if err != nil {
+		return nil, err
+	}
+
+	feePerKb, minFeePerKb, err := getFeePerKb(c)
+	if err != nil {
+		return nil, err
+	}
+
+	unsignedContract := wire.NewMsgTx(txVersion)
+	unsignedContract.AddTxOut(wire.NewTxOut(int64(args.amount), contractP2SHPkScript))
+	unsignedContract, contractFee, err := fundRawTransaction(c, unsignedContract, feePerKb)
+	if err != nil {
+		return nil, fmt.Errorf("fundrawtransaction: %v", err)
+	}
+	contractTx, complete, err := c.SignRawTransaction(unsignedContract)
+	if err != nil {
+		return nil, fmt.Errorf("signrawtransaction: %v", err)
+	}
+	if !complete {
+		return nil, errors.New("signrawtransaction: failed to completely sign contract transaction")
+	}
+
+	contractTxHash := contractTx.TxHash()
+
+	refundTx, refundFee, err := buildRefund(c, contract, contractTx, feePerKb, minFeePerKb)
+	if err != nil {
+		return nil, err
+	}
+
+	return &builtContract{
+		contract,
+		contractP2SH,
+		&contractTxHash,
+		contractTx,
+		contractFee,
+		refundTx,
+		refundFee,
+	}, nil
+}
+
+func buildRefund(c *rpc.Client, contract []byte, contractTx *wire.MsgTx, feePerKb, minFeePerKb xzcutil.Amount) (
+	refundTx *wire.MsgTx, refundFee xzcutil.Amount, err error) {
+
+	contractP2SH, err := xzcutil.NewAddressScriptHash(contract, chainParams)
+	if err != nil {
+		return nil, 0, err
+	}
+	contractP2SHPkScript, err := txscript.PayToAddrScript(contractP2SH)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	contractTxHash := contractTx.TxHash()
+	contractOutPoint := wire.OutPoint{Hash: contractTxHash, Index: ^uint32(0)}
+	for i, o := range contractTx.TxOut {
+		if bytes.Equal(o.PkScript, contractP2SHPkScript) {
+			contractOutPoint.Index = uint32(i)
+			break
+		}
+	}
+	if contractOutPoint.Index == ^uint32(0) {
+		return nil, 0, errors.New("contract tx does not contain a P2SH contract payment")
+	}
+
+	refundAddress, err := getRawChangeAddress(c)
+	if err != nil {
+		return nil, 0, fmt.Errorf("getrawchangeaddress: %v", err)
+	}
+	refundOutScript, err := txscript.PayToAddrScript(refundAddress)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	pushes, err := txscript.ExtractAtomicSwapDataPushes(contract)
+	if err != nil {
+		// expected to only be called with good input
+		panic(err)
+	}
+
+	refundAddr, err := xzcutil.NewAddressPubKeyHash(pushes.RefundHash160[:], chainParams)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	refundTx = wire.NewMsgTx(txVersion)
+	refundTx.LockTime = uint32(pushes.LockTime)
+	refundTx.AddTxOut(wire.NewTxOut(0, refundOutScript)) // amount set below
+	refundSize := estimateRefundSerializeSize(contract, refundTx.TxOut)
+	refundFee = txrules.FeeForSerializeSize(feePerKb, refundSize)
+	refundTx.TxOut[0].Value = contractTx.TxOut[contractOutPoint.Index].Value - int64(refundFee)
+	if txrules.IsDustOutput(refundTx.TxOut[0], minFeePerKb) {
+		return nil, 0, fmt.Errorf("refund output value of %v is dust", xzcutil.Amount(refundTx.TxOut[0].Value))
+	}
+
+	txIn := wire.NewTxIn(&contractOutPoint, nil, nil)
+	txIn.Sequence = 0
+	refundTx.AddTxIn(txIn)
+
+	refundSig, refundPubKey, err := createSig(refundTx, 0, contract, refundAddr, c)
+	if err != nil {
+		return nil, 0, err
+	}
+	refundSigScript, err := refundP2SHContract(contract, refundSig, refundPubKey)
+	if err != nil {
+		return nil, 0, err
+	}
+	refundTx.TxIn[0].SignatureScript = refundSigScript
+
+	if verify {
+		e, err := txscript.NewEngine(contractTx.TxOut[contractOutPoint.Index].PkScript,
+			refundTx, 0, txscript.StandardVerifyFlags, txscript.NewSigCache(10),
+			txscript.NewTxSigHashes(refundTx), contractTx.TxOut[contractOutPoint.Index].Value)
+		if err != nil {
+			panic(err)
+		}
+		err = e.Execute()
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	return refundTx, refundFee, nil
+}
+
+func sha256Hash(x []byte) []byte {
+	h := sha256.Sum256(x)
+	return h[:]
+}
+
+func calcFeePerKb(absoluteFee xzcutil.Amount, serializeSize int) float64 {
+	return float64(absoluteFee) / float64(serializeSize) / 1e5
+}
+
+func (cmd *initiateCmd) runCommand(c *rpc.Client) error {
+	var secret [secretSize]byte
+	_, err := rand.Read(secret[:])
+	if err != nil {
+		return err
+	}
+	secretHash := sha256Hash(secret[:])
+
+	// locktime after 500,000,000 (Tue Nov  5 00:53:20 1985 UTC) is interpreted
+	// as a unix time rather than a block height.
+	locktime := time.Now().Add(48 * time.Hour).Unix()
+
+	b, err := buildContract(c, &contractArgs{
+		them:       cmd.cp2Addr,
+		amount:     cmd.amount,
+		locktime:   locktime,
+		secretHash: secretHash,
+	})
+	if err != nil {
+		return err
+	}
+
+	refundTxHash := b.refundTx.TxHash()
+	contractFeePerKb := calcFeePerKb(b.contractFee, b.contractTx.SerializeSize())
+	refundFeePerKb := calcFeePerKb(b.refundFee, b.refundTx.SerializeSize())
+
+	fmt.Printf("Secret:      %x\n", secret)
+	fmt.Printf("Secret hash: %x\n\n", secretHash)
+	fmt.Printf("Contract fee: %v (%0.8f XZC/kB)\n", b.contractFee, contractFeePerKb)
+	fmt.Printf("Refund fee:   %v (%0.8f XZC/kB)\n\n", b.refundFee, refundFeePerKb)
+	fmt.Printf("Contract (%v):\n", b.contractP2SH)
+	fmt.Printf("%x\n\n", b.contract)
+	var contractBuf bytes.Buffer
+	contractBuf.Grow(b.contractTx.SerializeSize())
+	b.contractTx.Serialize(&contractBuf)
+	fmt.Printf("Contract transaction (%v):\n", b.contractTxHash)
+	fmt.Printf("%x\n\n", contractBuf.Bytes())
+	var refundBuf bytes.Buffer
+	refundBuf.Grow(b.refundTx.SerializeSize())
+	b.refundTx.Serialize(&refundBuf)
+	fmt.Printf("Refund transaction (%v):\n", &refundTxHash)
+	fmt.Printf("%x\n\n", refundBuf.Bytes())
+
+	return promptPublishTx(c, b.contractTx, "contract")
+}
+
+func (cmd *participateCmd) runCommand(c *rpc.Client) error {
+	// locktime after 500,000,000 (Tue Nov  5 00:53:20 1985 UTC) is interpreted
+	// as a unix time rather than a block height.
+	locktime := time.Now().Add(24 * time.Hour).Unix()
+
+	b, err := buildContract(c, &contractArgs{
+		them:       cmd.cp1Addr,
+		amount:     cmd.amount,
+		locktime:   locktime,
+		secretHash: cmd.secretHash,
+	})
+	if err != nil {
+		return err
+	}
+
+	refundTxHash := b.refundTx.TxHash()
+	contractFeePerKb := calcFeePerKb(b.contractFee, b.contractTx.SerializeSize())
+	refundFeePerKb := calcFeePerKb(b.refundFee, b.refundTx.SerializeSize())
+
+	fmt.Printf("Contract fee: %v (%0.8f XZC/kB)\n", b.contractFee, contractFeePerKb)
+	fmt.Printf("Refund fee:   %v (%0.8f XZC/kB)\n\n", b.refundFee, refundFeePerKb)
+	fmt.Printf("Contract (%v):\n", b.contractP2SH)
+	fmt.Printf("%x\n\n", b.contract)
+	var contractBuf bytes.Buffer
+	contractBuf.Grow(b.contractTx.SerializeSize())
+	b.contractTx.Serialize(&contractBuf)
+	fmt.Printf("Contract transaction (%v):\n", b.contractTxHash)
+	fmt.Printf("%x\n\n", contractBuf.Bytes())
+	var refundBuf bytes.Buffer
+	refundBuf.Grow(b.refundTx.SerializeSize())
+	b.refundTx.Serialize(&refundBuf)
+	fmt.Printf("Refund transaction (%v):\n", &refundTxHash)
+	fmt.Printf("%x\n\n", refundBuf.Bytes())
+
+	return promptPublishTx(c, b.contractTx, "contract")
+}
+
+func (cmd *redeemCmd) runCommand(c *rpc.Client) error {
+	pushes, err := txscript.ExtractAtomicSwapDataPushes(cmd.contract)
+	if err != nil {
+		return err
+	}
+	if pushes == nil {
+		return errors.New("contract is not an atomic swap script recognized by this tool")
+	}
+	recipientAddr, err := xzcutil.NewAddressPubKeyHash(pushes.RecipientHash160[:],
+		chainParams)
+	if err != nil {
+		return err
+	}
+	contractHash := xzcutil.Hash160(cmd.contract)
+	contractOut := -1
+	for i, out := range cmd.contractTx.TxOut {
+		sc, addrs, _, _ := txscript.ExtractPkScriptAddrs(out.PkScript, chainParams)
+		if sc == txscript.ScriptHashTy &&
+			bytes.Equal(addrs[0].(*xzcutil.AddressScriptHash).Hash160()[:], contractHash) {
+			contractOut = i
+			break
+		}
+	}
+	if contractOut == -1 {
+		return errors.New("transaction does not contain a contract output")
+	}
+
+	addr, err := getRawChangeAddress(c)
+	if err != nil {
+		return fmt.Errorf("getrawchangeaddres: %v", err)
+	}
+	outScript, err := txscript.PayToAddrScript(addr)
+	if err != nil {
+		return err
+	}
+
+	contractTxHash := cmd.contractTx.TxHash()
+	contractOutPoint := wire.OutPoint{
+		Hash:  contractTxHash,
+		Index: uint32(contractOut),
+	}
+
+	feePerKb, minFeePerKb, err := getFeePerKb(c)
+	if err != nil {
+		return err
+	}
+
+	redeemTx := wire.NewMsgTx(txVersion)
+	redeemTx.LockTime = uint32(pushes.LockTime)
+	redeemTx.AddTxIn(wire.NewTxIn(&contractOutPoint, nil, nil))
+	redeemTx.AddTxOut(wire.NewTxOut(0, outScript)) // amount set below
+	redeemSize := estimateRedeemSerializeSize(cmd.contract, redeemTx.TxOut)
+	fee := txrules.FeeForSerializeSize(feePerKb, redeemSize)
+	redeemTx.TxOut[0].Value = cmd.contractTx.TxOut[contractOut].Value - int64(fee)
+	if txrules.IsDustOutput(redeemTx.TxOut[0], minFeePerKb) {
+		return fmt.Errorf("redeem output value of %v is dust", xzcutil.Amount(redeemTx.TxOut[0].Value))
+	}
+
+	redeemSig, redeemPubKey, err := createSig(redeemTx, 0, cmd.contract, recipientAddr, c)
+	if err != nil {
+		return err
+	}
+	redeemSigScript, err := redeemP2SHContract(cmd.contract, redeemSig, redeemPubKey, cmd.secret)
+	if err != nil {
+		return err
+	}
+	redeemTx.TxIn[0].SignatureScript = redeemSigScript
+
+	redeemTxHash := redeemTx.TxHash()
+	redeemFeePerKb := calcFeePerKb(fee, redeemTx.SerializeSize())
+
+	var buf bytes.Buffer
+	buf.Grow(redeemTx.SerializeSize())
+	redeemTx.Serialize(&buf)
+	fmt.Printf("Redeem fee: %v (%0.8f XZC/kB)\n\n", fee, redeemFeePerKb)
+	fmt.Printf("Redeem transaction (%v):\n", &redeemTxHash)
+	fmt.Printf("%x\n\n", buf.Bytes())
+
+	if verify {
+		e, err := txscript.NewEngine(cmd.contractTx.TxOut[contractOutPoint.Index].PkScript,
+			redeemTx, 0, txscript.StandardVerifyFlags, txscript.NewSigCache(10),
+			txscript.NewTxSigHashes(redeemTx), cmd.contractTx.TxOut[contractOut].Value)
+		if err != nil {
+			panic(err)
+		}
+		err = e.Execute()
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	return promptPublishTx(c, redeemTx, "redeem")
+}
+
+func (cmd *refundCmd) runCommand(c *rpc.Client) error {
+	pushes, err := txscript.ExtractAtomicSwapDataPushes(cmd.contract)
+	if err != nil {
+		return err
+	}
+	if pushes == nil {
+		return errors.New("contract is not an atomic swap script recognized by this tool")
+	}
+
+	feePerKb, minFeePerKb, err := getFeePerKb(c)
+	if err != nil {
+		return err
+	}
+
+	refundTx, refundFee, err := buildRefund(c, cmd.contract, cmd.contractTx, feePerKb, minFeePerKb)
+	if err != nil {
+		return err
+	}
+	refundTxHash := refundTx.TxHash()
+	var buf bytes.Buffer
+	buf.Grow(refundTx.SerializeSize())
+	refundTx.Serialize(&buf)
+
+	refundFeePerKb := calcFeePerKb(refundFee, refundTx.SerializeSize())
+
+	fmt.Printf("Refund fee: %v (%0.8f XZC/kB)\n\n", refundFee, refundFeePerKb)
+	fmt.Printf("Refund transaction (%v):\n", &refundTxHash)
+	fmt.Printf("%x\n\n", buf.Bytes())
+
+	return promptPublishTx(c, refundTx, "refund")
+}
+
+func (cmd *extractSecretCmd) runCommand(c *rpc.Client) error {
+	return cmd.runOfflineCommand()
+}
+
+func (cmd *extractSecretCmd) runOfflineCommand() error {
+	// Loop over all pushed data from all inputs, searching for one that hashes
+	// to the expected hash.  By searching through all data pushes, we avoid any
+	// issues that could be caused by the initiator redeeming the participant's
+	// contract with some "nonstandard" or unrecognized transaction or script
+	// type.
+	for _, in := range cmd.redemptionTx.TxIn {
+		pushes, err := txscript.PushedData(in.SignatureScript)
+		if err != nil {
+			return err
+		}
+		for _, push := range pushes {
+			if bytes.Equal(sha256Hash(push), cmd.secretHash) {
+				fmt.Printf("Secret: %x\n", push)
+				return nil
+			}
+		}
+	}
+	return errors.New("transaction does not contain the secret")
+}
+
+func (cmd *auditContractCmd) runCommand(c *rpc.Client) error {
+	return cmd.runOfflineCommand()
+}
+
+func (cmd *auditContractCmd) runOfflineCommand() error {
+	contractHash160 := xzcutil.Hash160(cmd.contract)
+	contractOut := -1
+	for i, out := range cmd.contractTx.TxOut {
+		sc, addrs, _, err := txscript.ExtractPkScriptAddrs(out.PkScript, chainParams)
+		if err != nil || sc != txscript.ScriptHashTy {
+			continue
+		}
+		if bytes.Equal(addrs[0].(*xzcutil.AddressScriptHash).Hash160()[:], contractHash160) {
+			contractOut = i
+			break
+		}
+	}
+	if contractOut == -1 {
+		return errors.New("transaction does not contain the contract output")
+	}
+
+	pushes, err := txscript.ExtractAtomicSwapDataPushes(cmd.contract)
+	if err != nil {
+		return err
+	}
+	if pushes == nil {
+		return errors.New("contract is not an atomic swap script recognized by this tool")
+	}
+
+	contractAddr, err := xzcutil.NewAddressScriptHash(cmd.contract, chainParams)
+	if err != nil {
+		return err
+	}
+	recipientAddr, err := xzcutil.NewAddressPubKeyHash(pushes.RecipientHash160[:],
+		chainParams)
+	if err != nil {
+		return err
+	}
+	refundAddr, err := xzcutil.NewAddressPubKeyHash(pushes.RefundHash160[:],
+		chainParams)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Contract address:        %v\n", contractAddr)
+	fmt.Printf("Contract value:          %v\n", xzcutil.Amount(cmd.contractTx.TxOut[contractOut].Value))
+	fmt.Printf("Recipient address:       %v\n", recipientAddr)
+	fmt.Printf("Author's refund address: %v\n\n", refundAddr)
+
+	fmt.Printf("Secret hash: %x\n\n", pushes.SecretHash[:])
+
+	if pushes.LockTime >= int64(txscript.LockTimeThreshold) {
+		t := time.Unix(pushes.LockTime, 0)
+		fmt.Printf("Locktime: %v\n", t.UTC())
+		reachedAt := time.Until(t).Truncate(time.Second)
+		if reachedAt > 0 {
+			fmt.Printf("Locktime reached in %v\n", reachedAt)
+		} else {
+			fmt.Printf("Contract refund time lock has expired\n")
+		}
+	} else {
+		fmt.Printf("Locktime: block %v\n", pushes.LockTime)
+	}
+
+	return nil
+}
+
+// atomicSwapContract returns an output script that may be redeemed by one of
+// two signature scripts:
+//
+//   <their sig> <their pubkey> <initiator secret> 1
+//
+//   <my sig> <my pubkey> 0
+//
+// The first signature script is the normal redemption path done by the other
+// party and requires the initiator's secret.  The second signature script is
+// the refund path performed by us, but the refund can only be performed after
+// locktime.
+func atomicSwapContract(pkhMe, pkhThem *[ripemd160.Size]byte, locktime int64, secretHash []byte) ([]byte, error) {
+	b := txscript.NewScriptBuilder()
+
+	b.AddOp(txscript.OP_IF) // Normal redeem path
+	{
+		// Require initiator's secret to be known to redeem the output.
+		b.AddOp(txscript.OP_SHA256)
+		b.AddData(secretHash)
+		b.AddOp(txscript.OP_EQUALVERIFY)
+
+		// Verify their signature is being used to redeem the output.  This
+		// would normally end with OP_EQUALVERIFY OP_CHECKSIG but this has been
+		// moved outside of the branch to save a couple bytes.
+		b.AddOp(txscript.OP_DUP)
+		b.AddOp(txscript.OP_HASH160)
+		b.AddData(pkhThem[:])
+	}
+	b.AddOp(txscript.OP_ELSE) // Refund path
+	{
+		// Verify locktime and drop it off the stack (which is not done by
+		// CLTV).
+		b.AddInt64(locktime)
+		b.AddOp(txscript.OP_CHECKLOCKTIMEVERIFY)
+		b.AddOp(txscript.OP_DROP)
+
+		// Verify our signature is being used to redeem the output.  This would
+		// normally end with OP_EQUALVERIFY OP_CHECKSIG but this has been moved
+		// outside of the branch to save a couple bytes.
+		b.AddOp(txscript.OP_DUP)
+		b.AddOp(txscript.OP_HASH160)
+		b.AddData(pkhMe[:])
+	}
+	b.AddOp(txscript.OP_ENDIF)
+
+	// Complete the signature check.
+	b.AddOp(txscript.OP_EQUALVERIFY)
+	b.AddOp(txscript.OP_CHECKSIG)
+
+	return b.Script()
+}
+
+// redeemP2SHContract returns the signature script to redeem a contract output
+// using the redeemer's signature and the initiator's secret.  This function
+// assumes P2SH and appends the contract as the final data push.
+func redeemP2SHContract(contract, sig, pubkey, secret []byte) ([]byte, error) {
+	b := txscript.NewScriptBuilder()
+	b.AddData(sig)
+	b.AddData(pubkey)
+	b.AddData(secret)
+	b.AddInt64(1)
+	b.AddData(contract)
+	return b.Script()
+}
+
+// refundP2SHContract returns the signature script to refund a contract output
+// using the contract author's signature after the locktime has been reached.
+// This function assumes P2SH and appends the contract as the final data push.
+func refundP2SHContract(contract, sig, pubkey []byte) ([]byte, error) {
+	b := txscript.NewScriptBuilder()
+	b.AddData(sig)
+	b.AddData(pubkey)
+	b.AddInt64(0)
+	b.AddData(contract)
+	return b.Script()
+}

--- a/cmd/xzcatomicswap/main.go
+++ b/cmd/xzcatomicswap/main.go
@@ -35,7 +35,7 @@ const verify = true
 
 const secretSize = 32
 
-const txVersion = 2
+const txVersion = 1 // bitcoin 0.13.2 needs tx v1
 
 var (
 	chainParams = &chaincfg.MainNetParams
@@ -989,6 +989,9 @@ func (cmd *auditContractCmd) runOfflineCommand() error {
 	if pushes == nil {
 		return errors.New("contract is not an atomic swap script recognized by this tool")
 	}
+	if pushes.SecretSize != secretSize {
+		return fmt.Errorf("contract specifies strange secret size %v", pushes.SecretSize)
+	}
 
 	contractAddr, err := xzcutil.NewAddressScriptHash(cmd.contract, chainParams)
 	if err != nil {
@@ -1044,6 +1047,13 @@ func atomicSwapContract(pkhMe, pkhThem *[ripemd160.Size]byte, locktime int64, se
 
 	b.AddOp(txscript.OP_IF) // Normal redeem path
 	{
+		// Require initiator's secret to be a known length that the redeeming
+		// party can audit.  This is used to prevent fraud attacks between two
+		// currencies that have different maximum data sizes.
+		b.AddOp(txscript.OP_SIZE)
+		b.AddInt64(secretSize)
+		b.AddOp(txscript.OP_EQUALVERIFY)
+
 		// Require initiator's secret to be known to redeem the output.
 		b.AddOp(txscript.OP_SHA256)
 		b.AddData(secretHash)

--- a/cmd/xzcatomicswap/sizeest.go
+++ b/cmd/xzcatomicswap/sizeest.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2016 The btcsuite developers
+// Copyright (c) 2016-2017 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"github.com/zcoinofficial/xzcd/txscript"
+	"github.com/zcoinofficial/xzcd/wire"
+)
+
+// Worst case script and input/output size estimates.
+const (
+	// redeemAtomicSwapSigScriptSize is the worst case (largest) serialize size
+	// of a transaction input script to redeem the atomic swap contract.  This
+	// does not include final push for the contract itself.
+	//
+	//   - OP_DATA_73
+	//   - 72 bytes DER signature + 1 byte sighash
+	//   - OP_DATA_33
+	//   - 33 bytes serialized compressed pubkey
+	//   - OP_DATA_32
+	//   - 32 bytes secret
+	//   - OP_TRUE
+	redeemAtomicSwapSigScriptSize = 1 + 73 + 1 + 33 + 1 + 32 + 1
+
+	// refundAtomicSwapSigScriptSize is the worst case (largest) serialize size
+	// of a transaction input script that refunds a P2SH atomic swap output.
+	// This does not include final push for the contract itself.
+	//
+	//   - OP_DATA_73
+	//   - 72 bytes DER signature + 1 byte sighash
+	//   - OP_DATA_33
+	//   - 33 bytes serialized compressed pubkey
+	//   - OP_FALSE
+	refundAtomicSwapSigScriptSize = 1 + 73 + 1 + 33 + 1
+)
+
+func sumOutputSerializeSizes(outputs []*wire.TxOut) (serializeSize int) {
+	for _, txOut := range outputs {
+		serializeSize += txOut.SerializeSize()
+	}
+	return serializeSize
+}
+
+// inputSize returns the size of the transaction input needed to include a
+// signature script with size sigScriptSize.  It is calculated as:
+//
+//   - 32 bytes previous tx
+//   - 4 bytes output index
+//   - Compact int encoding sigScriptSize
+//   - sigScriptSize bytes signature script
+//   - 4 bytes sequence
+func inputSize(sigScriptSize int) int {
+	return 32 + 4 + wire.VarIntSerializeSize(uint64(sigScriptSize)) + sigScriptSize + 4
+}
+
+// estimateRedeemSerializeSize returns a worst case serialize size estimates for
+// a transaction that redeems an atomic swap P2SH output.
+func estimateRedeemSerializeSize(contract []byte, txOuts []*wire.TxOut) int {
+	contractPush, err := txscript.NewScriptBuilder().AddData(contract).Script()
+	if err != nil {
+		// Should never be hit since this script does exceed the limits.
+		panic(err)
+	}
+	contractPushSize := len(contractPush)
+
+	// 12 additional bytes are for version, locktime and expiry.
+	return 12 + wire.VarIntSerializeSize(1) +
+		wire.VarIntSerializeSize(uint64(len(txOuts))) +
+		inputSize(redeemAtomicSwapSigScriptSize+contractPushSize) +
+		sumOutputSerializeSizes(txOuts)
+}
+
+// estimateRefundSerializeSize returns a worst case serialize size estimates for
+// a transaction that refunds an atomic swap P2SH output.
+func estimateRefundSerializeSize(contract []byte, txOuts []*wire.TxOut) int {
+	contractPush, err := txscript.NewScriptBuilder().AddData(contract).Script()
+	if err != nil {
+		// Should never be hit since this script does exceed the limits.
+		panic(err)
+	}
+	contractPushSize := len(contractPush)
+
+	// 12 additional bytes are for version, locktime and expiry.
+	return 12 + wire.VarIntSerializeSize(1) +
+		wire.VarIntSerializeSize(uint64(len(txOuts))) +
+		inputSize(refundAtomicSwapSigScriptSize+contractPushSize) +
+		sumOutputSerializeSizes(txOuts)
+}


### PR DESCRIPTION
### An atomic swap has been done between Decred testnet & Zcoin testnet

The output of the swap has been pasted in the file below:

There remain some issues with `estimatefee` and/or `estimatesmartfee` but these can probably be resolved either with talked about changes to the atomic swap **cmd** code or in the xzcwallet/xzcd zcoin-specific code. The swap is nonetheless successful.

To view the transactions on the Zcoin blockchain please use the temporary explorer at:
http://45.76.2.255

API Example: http://45.76.2.255/api/getrawtransaction?txid=3583e1b9f2188862f0648e54ea29c4c2d8e8f31dfb015be80f18918cd106eb3f&decrypt=1

Note: `warning: falling back to mempool relay fee policy`

[xcat-xzc-dcr_2018_01_13.txt](https://github.com/decred/atomicswap/files/1631881/xcat-xzc-dcr_2018_01_13.txt)