### PR TITLE
Update btcatomicswap for Bitcoin Core v0.16.0.

### DIFF
--- a/cmd/btcatomicswap/main.go
+++ b/cmd/btcatomicswap/main.go
@@ -457,32 +457,59 @@ func fundRawTransaction(c *rpc.Client, tx *wire.MsgTx, feePerKb btcutil.Amount) 
 // wallet.  If unset, it attempts to find an estimate using estimatefee 6.  If
 // both of these fail, it falls back to mempool relay fee policy.
 func getFeePerKb(c *rpc.Client) (useFee, relayFee btcutil.Amount, err error) {
-	info, err := c.GetInfo()
-	if err != nil {
-		return 0, 0, fmt.Errorf("getinfo: %v", err)
+	var netInfoResp struct {
+		RelayFee float64 `json:"relayfee"`
 	}
-	relayFee, err = btcutil.NewAmount(info.RelayFee)
+	var walletInfoResp struct {
+		PayTxFee float64 `json:"paytxfee"`
+	}
+	var estimateResp struct {
+		FeeRate float64 `json:"feerate"`
+	}
+
+	netInfoRawResp, err := c.RawRequest("getnetworkinfo", nil)
+	if err == nil {
+		err = json.Unmarshal(netInfoRawResp, &netInfoResp)
+		if err != nil {
+			return 0, 0, err
+		}
+	}
+	walletInfoRawResp, err := c.RawRequest("walletinfo", nil)
+	if err == nil {
+		err = json.Unmarshal(walletInfoRawResp, &walletInfoResp)
+		if err != nil {
+			return 0, 0, err
+		}
+	}
+
+	relayFee, err = btcutil.NewAmount(netInfoResp.RelayFee)
 	if err != nil {
 		return 0, 0, err
 	}
-	maxFee := info.PaytxFee
-	if info.PaytxFee != 0 {
-		if info.RelayFee > maxFee {
-			maxFee = info.RelayFee
+	payTxFee, err := btcutil.NewAmount(walletInfoResp.PayTxFee)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	// Use user-set wallet fee when set and not lower than the network relay
+	// fee.
+	if payTxFee != 0 {
+		maxFee := payTxFee
+		if relayFee > maxFee {
+			maxFee = relayFee
 		}
-		useFee, err = btcutil.NewAmount(maxFee)
-		return useFee, relayFee, err
+		return maxFee, relayFee, nil
 	}
 
 	params := []json.RawMessage{[]byte("6")}
-	estimateRawResp, err := c.RawRequest("estimatefee", params)
+	estimateRawResp, err := c.RawRequest("estimatesmartfee", params)
 	if err != nil {
 		return 0, 0, err
 	}
-	var estimateResp float64 = -1
+
 	err = json.Unmarshal(estimateRawResp, &estimateResp)
-	if err == nil && estimateResp != -1 {
-		useFee, err = btcutil.NewAmount(estimateResp)
+	if err == nil && estimateResp.FeeRate > 0 {
+		useFee, err = btcutil.NewAmount(estimateResp.FeeRate)
 		if relayFee > useFee {
 			useFee = relayFee
 		}
@@ -490,15 +517,15 @@ func getFeePerKb(c *rpc.Client) (useFee, relayFee btcutil.Amount, err error) {
 	}
 
 	fmt.Println("warning: falling back to mempool relay fee policy")
-	useFee, err = btcutil.NewAmount(info.RelayFee)
-	return useFee, relayFee, err
+	return relayFee, relayFee, nil
 }
 
 // getRawChangeAddress calls the getrawchangeaddress JSON-RPC method.  It is
 // implemented manually as the rpcclient implementation always passes the
 // account parameter which was removed in Bitcoin Core 0.15.
 func getRawChangeAddress(c *rpc.Client) (btcutil.Address, error) {
-	rawResp, err := c.RawRequest("getrawchangeaddress", nil)
+	params := []json.RawMessage{[]byte(`"legacy"`)}
+	rawResp, err := c.RawRequest("getrawchangeaddress", params)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This introduces the following changes for compatibility with the new
Bitcoin Core release:

* getinfo is no longer called and its use for fee rate determination
  has been replaced with getnetworkinfo and walletinfo.

* estimatefee is no longer called for fee estimation and has been
  replaced by estimatesmartfee.

* The legacy parameter has been added to calls to getrawchangeaddress
  to return P2PKH change addresses that can be used by the atomic swap
  contract.

Fixes #60.