### PR TITLE
Fix RPC method name

### DIFF
--- a/cmd/btcatomicswap/main.go
+++ b/cmd/btcatomicswap/main.go
@@ -474,7 +474,7 @@ func getFeePerKb(c *rpc.Client) (useFee, relayFee btcutil.Amount, err error) {
 			return 0, 0, err
 		}
 	}
-	walletInfoRawResp, err := c.RawRequest("walletinfo", nil)
+	walletInfoRawResp, err := c.RawRequest("getwalletinfo", nil)
 	if err == nil {
 		err = json.Unmarshal(walletInfoRawResp, &walletInfoResp)
 		if err != nil {


### PR DESCRIPTION
There is no walletinfo JSON-RPC method found in Bitcoin Core and the
call should be to getwalletinfo instead.