### PR TITLE
Verify refund address is P2PKH.

### DIFF
--- a/cmd/bchatomicswap/main.go
+++ b/cmd/bchatomicswap/main.go
@@ -553,6 +553,10 @@ func getRawChangeAddress(c *rpc.Client) (btcutil.Address, error) {
 		return nil, fmt.Errorf("address %v is not intended for use on %v",
 			addrStr, chainParams.Name)
 	}
+	if _, ok := addr.(*btcutil.AddressPubKeyHash); !ok {
+		return nil, fmt.Errorf("getrawchangeaddress: address %v is not P2PKH",
+			addr)
+	}
 	return addr, nil
 }
 

--- a/cmd/btcatomicswap/main.go
+++ b/cmd/btcatomicswap/main.go
@@ -542,6 +542,10 @@ func getRawChangeAddress(c *rpc.Client) (btcutil.Address, error) {
 		return nil, fmt.Errorf("address %v is not intended for use on %v",
 			addrStr, chainParams.Name)
 	}
+	if _, ok := addr.(*btcutil.AddressPubKeyHash); !ok {
+		return nil, fmt.Errorf("getrawchangeaddress: address %v is not P2PKH",
+			addr)
+	}
 	return addr, nil
 }
 

--- a/cmd/dcratomicswap/main.go
+++ b/cmd/dcratomicswap/main.go
@@ -471,6 +471,9 @@ func buildContract(ctx context.Context, c pb.WalletServiceClient, args *contract
 	if err != nil {
 		return nil, err
 	}
+	if _, ok := refundAddr.(*dcrutil.AddressPubKeyHash); !ok {
+		return nil, fmt.Errorf("NextAddress: address %v is not P2PKH", refundAddr)
+	}
 
 	contract, err := atomicSwapContract(refundAddr.Hash160(), args.them.Hash160(),
 		args.locktime, args.secretHash)

--- a/cmd/ltcatomicswap/main.go
+++ b/cmd/ltcatomicswap/main.go
@@ -542,6 +542,10 @@ func getRawChangeAddress(c *rpc.Client) (ltcutil.Address, error) {
 		return nil, fmt.Errorf("address %v is not intended for use on %v",
 			addrStr, chainParams.Name)
 	}
+	if _, ok := addr.(*ltcutil.AddressPubKeyHash); !ok {
+		return nil, fmt.Errorf("getrawchangeaddress: address %v is not P2PKH",
+			addr)
+	}
 	return addr, nil
 }
 

--- a/cmd/monaatomicswap/main.go
+++ b/cmd/monaatomicswap/main.go
@@ -543,6 +543,10 @@ func getRawChangeAddress(c *rpc.Client) (monautil.Address, error) {
 		return nil, fmt.Errorf("address %v is not intended for use on %v",
 			addrStr, chainParams.Name)
 	}
+	if _, ok := addr.(*monautil.AddressPubKeyHash); !ok {
+		return nil, fmt.Errorf("getrawchangeaddress: address %v is not P2PKH",
+			addr)
+	}
 	return addr, nil
 }
 

--- a/cmd/partatomicswap/main.go
+++ b/cmd/partatomicswap/main.go
@@ -545,6 +545,10 @@ func getRawChangeAddress(c *rpc.Client) (partutil.Address, error) {
 		return nil, fmt.Errorf("address %v is not intended for use on %v",
 			addrStr, chainParams.Name)
 	}
+	if _, ok := addr.(*partutil.AddressPubKeyHash); !ok {
+		return nil, fmt.Errorf("getrawchangeaddress: address %v is not P2PKH",
+			addr)
+	}
 	return addr, nil
 }
 

--- a/cmd/viaatomicswap/main.go
+++ b/cmd/viaatomicswap/main.go
@@ -543,6 +543,10 @@ func getRawChangeAddress(c *rpc.Client) (viautil.Address, error) {
 		return nil, fmt.Errorf("address %v is not intended for use on %v",
 			addrStr, chainParams.Name)
 	}
+	if _, ok := addr.(*viautil.AddressPubKeyHash); !ok {
+		return nil, fmt.Errorf("getrawchangeaddress: address %v is not P2PKH",
+			addr)
+	}
 	return addr, nil
 }
 

--- a/cmd/vtcatomicswap/main.go
+++ b/cmd/vtcatomicswap/main.go
@@ -542,6 +542,10 @@ func getRawChangeAddress(c *rpc.Client) (vtcutil.Address, error) {
 		return nil, fmt.Errorf("address %v is not intended for use on %v",
 			addrStr, chainParams.Name)
 	}
+	if _, ok := addr.(*vtcutil.AddressPubKeyHash); !ok {
+		return nil, fmt.Errorf("getrawchangeaddress: address %v is not P2PKH",
+			addr)
+	}
 	return addr, nil
 }
 

--- a/cmd/xzcatomicswap/main.go
+++ b/cmd/xzcatomicswap/main.go
@@ -516,6 +516,10 @@ func getRawChangeAddress(c *rpc.Client) (xzcutil.Address, error) {
 		return nil, fmt.Errorf("address %v is not intended for use on %v",
 			addrStr, chainParams.Name)
 	}
+	if _, ok := addr.(*xzcutil.AddressPubKeyHash); !ok {
+		return nil, fmt.Errorf("getrawchangeaddress: address %v is not P2PKH",
+			addr)
+	}
 	return addr, nil
 }
 


### PR DESCRIPTION
If the wallet being queried has added segwit support, and the RPC
invocation has not been updated to explicitly request a P2PKH refund
address, the wallet may return a P2SH-witness address that, while
still having a Hash160 method, is not the correct type and may lead to
unspendable/lost coins if a refund must be made.

Closes #68.