### PR TITLE
add threefold token as externally supported coin

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ exists for the following coins and wallets:
 * Viacoin ([Viacoin Core](https://github.com/viacoin/viacoin))
 * Zcoin ([Zcoin Core](https://github.com/zcoinofficial/zcoin))
 
+External support exists for the following coins and wallets:
+
+* ThreeFold Token ([ThreeFold Chain](https://github.com/threefoldfoundation/tfchain))
+
 Pull requests implementing support for additional cryptocurrencies and wallets
 are encouraged.  See [GitHub project
 1](https://github.com/decred/atomicswap/projects/1) for the status of coins


### PR DESCRIPTION
external support meaning it is supported in
a repository other than this one

You can find a documented example on how to use the `tfchaind` daemon and `tfchainc` tool in order to atomically swap with ThreeFold Tokens at <https://github.com/threefoldfoundation/tfchain/blob/master/doc/atomicswap.md>.