### PR TITLE
'fundrawtransaction' - use a legacy change address

### DIFF
--- a/cmd/ltcatomicswap/main.go
+++ b/cmd/ltcatomicswap/main.go
@@ -415,9 +415,11 @@ func fundRawTransaction(c *rpc.Client, tx *wire.MsgTx, feePerKb ltcutil.Amount) 
 		return nil, 0, err
 	}
 	param1, err := json.Marshal(struct {
-		FeeRate float64 `json:"feeRate"`
+		FeeRate    float64 `json:"feeRate"`
+		ChangeType string  `json:"change_type"`
 	}{
-		FeeRate: feePerKb.ToBTC(),
+		FeeRate:    feePerKb.ToBTC(),
+		ChangeType: "legacy",
 	})
 	if err != nil {
 		return nil, 0, err


### PR DESCRIPTION
_"Bad change output when calling litecoin 'fundrawtransaction' rpc"_

Explanation:
Decred atomic swaps is using "legacy" litecoin addresses but the default is not "legacy" for change outputs unless set with litecoind ... -addresstype / -changetype. If not then the changetype for the call to RPC "fundrawtransaction" should be explicitly set.


_litecoind:_

Wallet options:

  -addresstype
       What type of addresses to use ("legacy", "p2sh-segwit", or "bech32", default: "p2sh-segwit")

  -changetype
       What type of change to use ("legacy", "p2sh-segwit", or "bech32").
       Default is same as -addresstype, except when -addresstype=p2sh-segwit a native segwit output is used when sending to a native segwit address)

