### PR TITLE
Use raw request on bitcoin rpc calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ TsfWDVTAcsLaHUhHnLLKkGnZuJz2vkmM6Vr
 
 _Party B runs:_
 ```
-$ bitcoin-cli -testnet getnewaddress
+$ bitcoin-cli -testnet getnewaddress "" "legacy"
 n31og5QGuS28dmHpDH6PQD5wmVQ2K2spAG
 ```
 


### PR DESCRIPTION
fixes #105

I also updated the readme as we need a P2PKH address and now bitcoin's code set `p2sh-segwit` as the default address type.