### PR TITLE
Regression Testing Flag

### DIFF
--- a/cmd/btcatomicswap/main.go
+++ b/cmd/btcatomicswap/main.go
@@ -46,6 +46,7 @@ var (
 	rpcuserFlag = flagset.String("rpcuser", "", "username for wallet RPC authentication")
 	rpcpassFlag = flagset.String("rpcpass", "", "password for wallet RPC authentication")
 	testnetFlag = flagset.Bool("testnet", false, "use testnet network")
+	regtestFlag = flagset.Bool("regtest", false, "use regtest network")
 )
 
 // There are two directions that the atomic swap can be performed, as the
@@ -188,6 +189,10 @@ func run() (err error, showUsage bool) {
 
 	if *testnetFlag {
 		chainParams = &chaincfg.TestNet3Params
+	}
+
+	if *regtestFlag {
+		chainParams = &chaincfg.RegressionNetParams
 	}
 
 	var cmd command


### PR DESCRIPTION
### Description

It would be useful to be able to utilize regression testing with a `--regtest` flag via command line. I just added the source for Bitcoin only, but, can quickly implement it for other chains.